### PR TITLE
feat/#5 OCR 연동 및 조회 API 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.2'
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 	implementation 'org.apache.pdfbox:pdfbox:3.0.3'
+	implementation 'com.azure:azure-ai-documentintelligence:1.0.7'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/backend/src/main/java/com/safesign/backend/domain/contract/enums/ContractStatus.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/enums/ContractStatus.java
@@ -2,5 +2,10 @@ package com.safesign.backend.domain.contract.enums;
 
 public enum ContractStatus {
     UPLOADED,
-    FAILED
+    OCR_PROCESSING,
+    OCR_COMPLETED,
+    OCR_FAILED,
+    AI_PROCESSING,
+    AI_COMPLETED,
+    AI_FAILED
 }

--- a/backend/src/main/java/com/safesign/backend/domain/contract/service/ContractService.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/service/ContractService.java
@@ -11,6 +11,8 @@ import com.safesign.backend.domain.contract.repository.ContractFileRepository;
 import com.safesign.backend.domain.contract.repository.ContractRepository;
 import com.safesign.backend.domain.user.entity.User;
 import com.safesign.backend.domain.user.repository.UserRepository;
+import com.safesign.backend.global.exception.CustomException;
+import com.safesign.backend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.pdmodel.PDDocument;
@@ -35,7 +37,7 @@ public class ContractService {
         validateFilesExist(files);
 
         User user = userRepository.findById(1L)
-                .orElseThrow(() -> new IllegalArgumentException("테스트 사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         return switch (uploadType) {
             case PDF -> uploadPdf(files, title, user);
@@ -45,7 +47,7 @@ public class ContractService {
 
     private ContractUploadResponse uploadPdf(List<MultipartFile> files, String title, User user) {
         if (files.size() != 1) {
-            throw new IllegalArgumentException("PDF 업로드는 파일 1개만 가능합니다.");
+            throw new CustomException(ErrorCode.INVALID_PDF_FILE_COUNT);
         }
 
         MultipartFile file = files.get(0);
@@ -127,29 +129,29 @@ public class ContractService {
 
     private void validateFilesExist(List<MultipartFile> files) {
         if (files == null || files.isEmpty()) {
-            throw new IllegalArgumentException("업로드 파일이 비어 있습니다.");
+            throw new CustomException(ErrorCode.EMPTY_UPLOAD_FILE);
         }
     }
 
     private void validatePdfFile(MultipartFile file) {
         if (file == null || file.isEmpty()) {
-            throw new IllegalArgumentException("업로드 파일이 비어 있습니다.");
+            throw new CustomException(ErrorCode.EMPTY_UPLOAD_FILE);
         }
 
         if (!"application/pdf".equals(file.getContentType())) {
-            throw new IllegalArgumentException("PDF 파일만 업로드할 수 있습니다.");
+            throw new CustomException(ErrorCode.INVALID_PDF_UPLOAD);
         }
     }
 
     private void validateImageFiles(List<MultipartFile> files) {
         for (MultipartFile file : files) {
             if (file == null || file.isEmpty()) {
-                throw new IllegalArgumentException("업로드 파일이 비어 있습니다.");
+                throw new CustomException(ErrorCode.EMPTY_UPLOAD_FILE);
             }
 
             String contentType = file.getContentType();
             if (contentType == null || !contentType.startsWith("image/")) {
-                throw new IllegalArgumentException("이미지 파일만 업로드할 수 있습니다.");
+                throw new CustomException(ErrorCode.INVALID_IMAGE_UPLOAD);
             }
         }
     }
@@ -158,7 +160,7 @@ public class ContractService {
         try (PDDocument document = Loader.loadPDF(file.getBytes())) {
             return document.getNumberOfPages();
         } catch (IOException e) {
-            throw new IllegalArgumentException("PDF 페이지 수를 읽는 중 오류가 발생했습니다.", e);
+            throw new CustomException(ErrorCode.PDF_PAGE_COUNT_READ_FAILED);
         }
     }
 }

--- a/backend/src/main/java/com/safesign/backend/domain/contract/service/FileStorageService.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/service/FileStorageService.java
@@ -1,6 +1,8 @@
 package com.safesign.backend.domain.contract.service;
 
 import com.safesign.backend.domain.contract.dto.response.StoredFileInfo;
+import com.safesign.backend.global.exception.CustomException;
+import com.safesign.backend.global.exception.ErrorCode;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -39,13 +41,13 @@ public class FileStorageService {
                     .build();
 
         } catch (IOException e) {
-            throw new RuntimeException("파일 저장 중 오류가 발생했습니다.", e);
+            throw new CustomException(ErrorCode.FILE_STORAGE_FAILED);
         }
     }
 
     private void validateFileExists(MultipartFile file) {
         if (file == null || file.isEmpty()) {
-            throw new IllegalArgumentException("업로드 파일이 비어 있습니다.");
+            throw new CustomException(ErrorCode.EMPTY_UPLOAD_FILE);
         }
     }
 

--- a/backend/src/main/java/com/safesign/backend/domain/ocr/client/AzureOcrClient.java
+++ b/backend/src/main/java/com/safesign/backend/domain/ocr/client/AzureOcrClient.java
@@ -1,0 +1,26 @@
+package com.safesign.backend.domain.ocr.client;
+
+import com.azure.ai.documentintelligence.DocumentIntelligenceClient;
+import com.azure.ai.documentintelligence.models.AnalyzeDocumentOptions;
+import com.azure.ai.documentintelligence.models.AnalyzeResult;
+import com.azure.core.util.BinaryData;
+import com.azure.core.util.polling.SyncPoller;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AzureOcrClient {
+
+    private final DocumentIntelligenceClient documentIntelligenceClient;
+
+    public AnalyzeResult analyze(byte[] fileBytes, String modelId) {
+        AnalyzeDocumentOptions options =
+                new AnalyzeDocumentOptions(BinaryData.fromBytes(fileBytes));
+
+        SyncPoller<?, AnalyzeResult> poller =
+                documentIntelligenceClient.beginAnalyzeDocument(modelId, options);
+
+        return poller.getFinalResult();
+    }
+}

--- a/backend/src/main/java/com/safesign/backend/domain/ocr/config/AzureOcrConfig.java
+++ b/backend/src/main/java/com/safesign/backend/domain/ocr/config/AzureOcrConfig.java
@@ -1,0 +1,23 @@
+package com.safesign.backend.domain.ocr.config;
+
+import com.azure.ai.documentintelligence.DocumentIntelligenceClient;
+import com.azure.ai.documentintelligence.DocumentIntelligenceClientBuilder;
+import com.azure.core.credential.AzureKeyCredential;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(AzureOcrProperties.class)
+public class AzureOcrConfig {
+
+    @Bean
+    public DocumentIntelligenceClient documentIntelligenceClient(
+            AzureOcrProperties properties
+    ) {
+        return new DocumentIntelligenceClientBuilder()
+                .endpoint(properties.endpoint())
+                .credential(new AzureKeyCredential(properties.key()))
+                .buildClient();
+    }
+}

--- a/backend/src/main/java/com/safesign/backend/domain/ocr/config/AzureOcrProperties.java
+++ b/backend/src/main/java/com/safesign/backend/domain/ocr/config/AzureOcrProperties.java
@@ -1,0 +1,11 @@
+package com.safesign.backend.domain.ocr.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "azure.document-intelligence")
+public record AzureOcrProperties(
+        String endpoint,
+        String key,
+        String modelId
+) {
+}

--- a/backend/src/main/java/com/safesign/backend/domain/ocr/controller/OcrController.java
+++ b/backend/src/main/java/com/safesign/backend/domain/ocr/controller/OcrController.java
@@ -1,0 +1,28 @@
+package com.safesign.backend.domain.ocr.controller;
+
+import com.safesign.backend.domain.ocr.dto.response.OcrResponse;
+import com.safesign.backend.domain.ocr.service.OcrQueryService;
+import com.safesign.backend.domain.ocr.service.OcrService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/contracts")
+public class OcrController {
+
+    private final OcrService ocrService;
+    private final OcrQueryService ocrQueryService;
+
+    @PostMapping("/{contractId}/ocr")
+    public ResponseEntity<String> processOcr(@PathVariable Long contractId) {
+        ocrService.process(contractId);
+        return ResponseEntity.ok("OCR 처리가 완료되었습니다.");
+    }
+
+    @GetMapping("/{contractId}/ocr")
+    public ResponseEntity<OcrResponse> getOcrResult(@PathVariable Long contractId) {
+        return ResponseEntity.ok(ocrQueryService.getLatestOcrResult(contractId));
+    }
+}

--- a/backend/src/main/java/com/safesign/backend/domain/ocr/dto/response/OcrLineResponse.java
+++ b/backend/src/main/java/com/safesign/backend/domain/ocr/dto/response/OcrLineResponse.java
@@ -1,0 +1,12 @@
+package com.safesign.backend.domain.ocr.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class OcrLineResponse {
+    private Integer lineNo;
+    private String content;
+    private String polygonJson;
+}

--- a/backend/src/main/java/com/safesign/backend/domain/ocr/dto/response/OcrPageResponse.java
+++ b/backend/src/main/java/com/safesign/backend/domain/ocr/dto/response/OcrPageResponse.java
@@ -1,0 +1,14 @@
+package com.safesign.backend.domain.ocr.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class OcrPageResponse {
+    private Integer pageNumber;
+    private String pageText;
+    private List<OcrLineResponse> lines;
+}

--- a/backend/src/main/java/com/safesign/backend/domain/ocr/dto/response/OcrResponse.java
+++ b/backend/src/main/java/com/safesign/backend/domain/ocr/dto/response/OcrResponse.java
@@ -1,0 +1,18 @@
+package com.safesign.backend.domain.ocr.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class OcrResponse {
+    private Long contractId;
+    private Long ocrResultId;
+    private String provider;
+    private String modelId;
+    private String status;
+    private String fullText;
+    private List<OcrPageResponse> pages;
+}

--- a/backend/src/main/java/com/safesign/backend/domain/ocr/entity/OcrLine.java
+++ b/backend/src/main/java/com/safesign/backend/domain/ocr/entity/OcrLine.java
@@ -1,0 +1,55 @@
+package com.safesign.backend.domain.ocr.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "ocr_line")
+public class OcrLine {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long ocrLineId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ocr_page_id", nullable = false)
+    private OcrPage ocrPage;
+
+    @Column(nullable = false)
+    private Integer lineNo;
+
+    @Lob
+    @Column(nullable = false)
+    private String content;
+
+    @Lob
+    private String polygonJson;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public OcrLine(
+            OcrPage ocrPage,
+            Integer lineNo,
+            String content,
+            String polygonJson
+    ) {
+        this.ocrPage = ocrPage;
+        this.lineNo = lineNo;
+        this.content = content;
+        this.polygonJson = polygonJson;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/com/safesign/backend/domain/ocr/entity/OcrPage.java
+++ b/backend/src/main/java/com/safesign/backend/domain/ocr/entity/OcrPage.java
@@ -1,0 +1,65 @@
+package com.safesign.backend.domain.ocr.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "ocr_page")
+public class OcrPage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long ocrPageId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ocr_result_id", nullable = false)
+    private OcrResult ocrResult;
+
+    @Column(nullable = false)
+    private Integer pageNumber;
+
+    @Column(precision = 10, scale = 2)
+    private BigDecimal width;
+
+    @Column(precision = 10, scale = 2)
+    private BigDecimal height;
+
+    @Column(length = 20)
+    private String unit;
+
+    @Lob
+    private String pageText;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public OcrPage(
+            OcrResult ocrResult,
+            Integer pageNumber,
+            BigDecimal width,
+            BigDecimal height,
+            String unit,
+            String pageText
+    ) {
+        this.ocrResult = ocrResult;
+        this.pageNumber = pageNumber;
+        this.width = width;
+        this.height = height;
+        this.unit = unit;
+        this.pageText = pageText;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/com/safesign/backend/domain/ocr/entity/OcrResult.java
+++ b/backend/src/main/java/com/safesign/backend/domain/ocr/entity/OcrResult.java
@@ -1,0 +1,111 @@
+package com.safesign.backend.domain.ocr.entity;
+
+import com.safesign.backend.domain.contract.entity.Contract;
+import com.safesign.backend.domain.ocr.enums.OcrStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "ocr_result")
+public class OcrResult {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long ocrResultId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "contract_id", nullable = false)
+    private Contract contract;
+
+    @Column(nullable = false, length = 30)
+    private String provider;
+
+    @Column(nullable = false, length = 100)
+    private String modelId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private OcrStatus status;
+
+    @Lob
+    private String fullText;
+
+    @Lob
+    private String rawJson;
+
+    private LocalDateTime startedAt;
+
+    private LocalDateTime completedAt;
+
+    @Column(length = 300)
+    private String failureReason;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public OcrResult(
+            Contract contract,
+            String provider,
+            String modelId,
+            OcrStatus status,
+            String fullText,
+            String rawJson,
+            LocalDateTime startedAt,
+            LocalDateTime completedAt,
+            String failureReason
+    ) {
+        this.contract = contract;
+        this.provider = provider;
+        this.modelId = modelId;
+        this.status = status;
+        this.fullText = fullText;
+        this.rawJson = rawJson;
+        this.startedAt = startedAt;
+        this.completedAt = completedAt;
+        this.failureReason = failureReason;
+    }
+
+    public void complete(String fullText, String rawJson) {
+        this.fullText = fullText;
+        this.rawJson = rawJson;
+        this.status = OcrStatus.COMPLETED;
+        this.completedAt = LocalDateTime.now();
+        this.failureReason = null;
+    }
+
+    public void fail(String failureReason) {
+        this.status = OcrStatus.FAILED;
+        this.failureReason = failureReason;
+        this.completedAt = LocalDateTime.now();
+    }
+
+    public void updateStatus(OcrStatus status) {
+        this.status = status;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+
+        if (this.startedAt == null) {
+            this.startedAt = LocalDateTime.now();
+        }
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/com/safesign/backend/domain/ocr/enums/OcrStatus.java
+++ b/backend/src/main/java/com/safesign/backend/domain/ocr/enums/OcrStatus.java
@@ -1,0 +1,7 @@
+package com.safesign.backend.domain.ocr.enums;
+
+public enum OcrStatus {
+    PROCESSING,
+    COMPLETED,
+    FAILED
+}

--- a/backend/src/main/java/com/safesign/backend/domain/ocr/repository/OcrLineRepository.java
+++ b/backend/src/main/java/com/safesign/backend/domain/ocr/repository/OcrLineRepository.java
@@ -1,0 +1,19 @@
+package com.safesign.backend.domain.ocr.repository;
+
+import com.safesign.backend.domain.ocr.entity.OcrLine;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface OcrLineRepository extends JpaRepository<OcrLine, Long> {
+
+    @Query("""
+        select l
+        from OcrLine l
+        where l.ocrPage.ocrPageId = :ocrPageId
+        order by l.lineNo asc
+    """)
+    List<OcrLine> findAllByOcrPageId(@Param("ocrPageId") Long ocrPageId);
+}

--- a/backend/src/main/java/com/safesign/backend/domain/ocr/repository/OcrPageRepository.java
+++ b/backend/src/main/java/com/safesign/backend/domain/ocr/repository/OcrPageRepository.java
@@ -1,0 +1,19 @@
+package com.safesign.backend.domain.ocr.repository;
+
+import com.safesign.backend.domain.ocr.entity.OcrPage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface OcrPageRepository extends JpaRepository<OcrPage, Long> {
+
+    @Query("""
+        select p
+        from OcrPage p
+        where p.ocrResult.ocrResultId = :ocrResultId
+        order by p.pageNumber asc
+    """)
+    List<OcrPage> findAllByOcrResultId(@Param("ocrResultId") Long ocrResultId);
+}

--- a/backend/src/main/java/com/safesign/backend/domain/ocr/repository/OcrResultRepository.java
+++ b/backend/src/main/java/com/safesign/backend/domain/ocr/repository/OcrResultRepository.java
@@ -1,0 +1,19 @@
+package com.safesign.backend.domain.ocr.repository;
+
+import com.safesign.backend.domain.ocr.entity.OcrResult;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface OcrResultRepository extends JpaRepository<OcrResult, Long> {
+
+    @Query("""
+        select o
+        from OcrResult o
+        where o.contract.contractId = :contractId
+        order by o.ocrResultId desc
+    """)
+    Optional<OcrResult> findLatestByContractId(@Param("contractId") Long contractId);
+}

--- a/backend/src/main/java/com/safesign/backend/domain/ocr/service/OcrQueryService.java
+++ b/backend/src/main/java/com/safesign/backend/domain/ocr/service/OcrQueryService.java
@@ -1,0 +1,71 @@
+package com.safesign.backend.domain.ocr.service;
+
+import com.safesign.backend.domain.ocr.dto.response.OcrLineResponse;
+import com.safesign.backend.domain.ocr.dto.response.OcrPageResponse;
+import com.safesign.backend.domain.ocr.dto.response.OcrResponse;
+import com.safesign.backend.domain.ocr.entity.OcrLine;
+import com.safesign.backend.domain.ocr.entity.OcrPage;
+import com.safesign.backend.domain.ocr.entity.OcrResult;
+import com.safesign.backend.domain.ocr.repository.OcrLineRepository;
+import com.safesign.backend.domain.ocr.repository.OcrPageRepository;
+import com.safesign.backend.domain.ocr.repository.OcrResultRepository;
+import com.safesign.backend.global.exception.CustomException;
+import com.safesign.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OcrQueryService {
+
+    private final OcrResultRepository ocrResultRepository;
+    private final OcrPageRepository ocrPageRepository;
+    private final OcrLineRepository ocrLineRepository;
+
+    public OcrResponse getLatestOcrResult(Long contractId) {
+        OcrResult ocrResult = ocrResultRepository.findLatestByContractId(contractId)
+                .orElseThrow(() -> new CustomException(ErrorCode.OCR_RESULT_NOT_FOUND));
+
+        List<OcrPage> pages = ocrPageRepository.findAllByOcrResultId(ocrResult.getOcrResultId());
+
+        List<OcrPageResponse> pageResponses = pages.stream()
+                .map(this::toPageResponse)
+                .toList();
+
+        return OcrResponse.builder()
+                .contractId(contractId)
+                .ocrResultId(ocrResult.getOcrResultId())
+                .provider(ocrResult.getProvider())
+                .modelId(ocrResult.getModelId())
+                .status(ocrResult.getStatus().name())
+                .fullText(ocrResult.getFullText())
+                .pages(pageResponses)
+                .build();
+    }
+
+    private OcrPageResponse toPageResponse(OcrPage page) {
+        List<OcrLine> lines = ocrLineRepository.findAllByOcrPageId(page.getOcrPageId());
+
+        List<OcrLineResponse> lineResponses = lines.stream()
+                .map(this::toLineResponse)
+                .toList();
+
+        return OcrPageResponse.builder()
+                .pageNumber(page.getPageNumber())
+                .pageText(page.getPageText())
+                .lines(lineResponses)
+                .build();
+    }
+
+    private OcrLineResponse toLineResponse(OcrLine line) {
+        return OcrLineResponse.builder()
+                .lineNo(line.getLineNo())
+                .content(line.getContent())
+                .polygonJson(line.getPolygonJson())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/safesign/backend/domain/ocr/service/OcrService.java
+++ b/backend/src/main/java/com/safesign/backend/domain/ocr/service/OcrService.java
@@ -1,0 +1,168 @@
+package com.safesign.backend.domain.ocr.service;
+
+import com.azure.ai.documentintelligence.models.AnalyzeResult;
+import com.azure.ai.documentintelligence.models.DocumentLine;
+import com.azure.ai.documentintelligence.models.DocumentPage;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.safesign.backend.domain.contract.entity.Contract;
+import com.safesign.backend.domain.contract.entity.ContractFile;
+import com.safesign.backend.domain.contract.enums.ContractStatus;
+import com.safesign.backend.domain.contract.repository.ContractRepository;
+import com.safesign.backend.domain.ocr.client.AzureOcrClient;
+import com.safesign.backend.domain.ocr.config.AzureOcrProperties;
+import com.safesign.backend.domain.ocr.entity.OcrLine;
+import com.safesign.backend.domain.ocr.entity.OcrPage;
+import com.safesign.backend.domain.ocr.entity.OcrResult;
+import com.safesign.backend.domain.ocr.enums.OcrStatus;
+import com.safesign.backend.domain.ocr.repository.OcrLineRepository;
+import com.safesign.backend.domain.ocr.repository.OcrPageRepository;
+import com.safesign.backend.domain.ocr.repository.OcrResultRepository;
+import com.safesign.backend.global.exception.CustomException;
+import com.safesign.backend.global.exception.ErrorCode;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class OcrService {
+
+    private static final String OCR_PROVIDER = "AZURE";
+
+    private final ContractRepository contractRepository;
+    private final OcrResultRepository ocrResultRepository;
+    private final OcrPageRepository ocrPageRepository;
+    private final OcrLineRepository ocrLineRepository;
+    private final AzureOcrClient azureOcrClient;
+    private final AzureOcrProperties azureOcrProperties;
+    private final ObjectMapper objectMapper;
+
+    public void process(Long contractId) {
+        Contract contract = contractRepository.findById(contractId)
+                .orElseThrow(() -> new CustomException(ErrorCode.CONTRACT_NOT_FOUND));
+
+        ContractFile contractFile = getFirstContractFile(contract);
+        contract.updateStatus(ContractStatus.OCR_PROCESSING);
+
+        OcrResult ocrResult = OcrResult.builder()
+                .contract(contract)
+                .provider(OCR_PROVIDER)
+                .modelId(azureOcrProperties.modelId())
+                .status(OcrStatus.PROCESSING)
+                .startedAt(LocalDateTime.now())
+                .build();
+
+        ocrResultRepository.save(ocrResult);
+
+        try {
+            byte[] fileBytes = Files.readAllBytes(Path.of(contractFile.getFileUrl()));
+            AnalyzeResult analyzeResult =
+                    azureOcrClient.analyze(fileBytes, azureOcrProperties.modelId());
+
+            ocrResult.complete(
+                    analyzeResult.getContent(),
+                    toJson(analyzeResult)
+            );
+
+            savePagesAndLines(ocrResult, analyzeResult);
+
+            contract.updateStatus(ContractStatus.OCR_COMPLETED);
+            contract.updateFailureReason(null);
+
+        } catch (CustomException e) {
+            ocrResult.fail(e.getMessage());
+            contract.updateStatus(ContractStatus.OCR_FAILED);
+            contract.updateFailureReason(e.getMessage());
+            throw e;
+
+        } catch (Exception e) {
+            ocrResult.fail(e.getMessage());
+            contract.updateStatus(ContractStatus.OCR_FAILED);
+            contract.updateFailureReason(e.getMessage());
+
+            throw new CustomException(ErrorCode.OCR_PROCESS_FAILED);
+        }
+    }
+
+    private ContractFile getFirstContractFile(Contract contract) {
+        List<ContractFile> files = contract.getContractFiles();
+
+        if (files == null || files.isEmpty()) {
+            throw new CustomException(ErrorCode.CONTRACT_FILE_NOT_FOUND);
+        }
+
+        return files.get(0);
+    }
+
+    private void savePagesAndLines(OcrResult ocrResult, AnalyzeResult analyzeResult) {
+        if (analyzeResult.getPages() == null) {
+            return;
+        }
+
+        for (DocumentPage page : analyzeResult.getPages()) {
+            OcrPage ocrPage = OcrPage.builder()
+                    .ocrResult(ocrResult)
+                    .pageNumber(page.getPageNumber())
+                    .width(toBigDecimal(page.getWidth()))
+                    .height(toBigDecimal(page.getHeight()))
+                    .unit(page.getUnit() != null ? page.getUnit().toString() : null)
+                    .pageText(extractPageText(page))
+                    .build();
+
+            ocrPageRepository.save(ocrPage);
+
+            List<DocumentLine> lines = page.getLines();
+            if (lines == null || lines.isEmpty()) {
+                continue;
+            }
+
+            for (int i = 0; i < lines.size(); i++) {
+                DocumentLine line = lines.get(i);
+
+                OcrLine ocrLine = OcrLine.builder()
+                        .ocrPage(ocrPage)
+                        .lineNo(i + 1)
+                        .content(line.getContent())
+                        .polygonJson(toJson(line.getPolygon()))
+                        .build();
+
+                ocrLineRepository.save(ocrLine);
+            }
+        }
+    }
+
+    private String extractPageText(DocumentPage page) {
+        if (page.getLines() == null || page.getLines().isEmpty()) {
+            return null;
+        }
+
+        return page.getLines().stream()
+                .map(DocumentLine::getContent)
+                .reduce((a, b) -> a + "\n" + b)
+                .orElse(null);
+    }
+
+    private BigDecimal toBigDecimal(Number value) {
+        return value == null ? null : BigDecimal.valueOf(value.doubleValue());
+    }
+
+    private String toJson(Object value) {
+        if (value == null) {
+            return null;
+        }
+
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            throw new CustomException(ErrorCode.OCR_PROCESS_FAILED);
+        }
+    }
+}

--- a/backend/src/main/java/com/safesign/backend/global/config/JacksonConfig.java
+++ b/backend/src/main/java/com/safesign/backend/global/config/JacksonConfig.java
@@ -1,0 +1,14 @@
+package com.safesign.backend.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+}

--- a/backend/src/main/java/com/safesign/backend/global/exception/CustomException.java
+++ b/backend/src/main/java/com/safesign/backend/global/exception/CustomException.java
@@ -1,0 +1,14 @@
+package com.safesign.backend.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/backend/src/main/java/com/safesign/backend/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/safesign/backend/global/exception/ErrorCode.java
@@ -1,0 +1,26 @@
+package com.safesign.backend.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    CONTRACT_NOT_FOUND(HttpStatus.NOT_FOUND, "계약서를 찾을 수 없습니다."),
+    CONTRACT_FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "계약서 파일을 찾을 수 없습니다."),
+    OCR_RESULT_NOT_FOUND(HttpStatus.NOT_FOUND, "OCR 결과를 찾을 수 없습니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+    EMPTY_UPLOAD_FILE(HttpStatus.BAD_REQUEST, "업로드 파일이 비어 있습니다."),
+    INVALID_PDF_UPLOAD(HttpStatus.BAD_REQUEST, "PDF 파일만 업로드할 수 있습니다."),
+    INVALID_IMAGE_UPLOAD(HttpStatus.BAD_REQUEST, "이미지 파일만 업로드할 수 있습니다."),
+    INVALID_PDF_FILE_COUNT(HttpStatus.BAD_REQUEST, "PDF 업로드는 파일 1개만 가능합니다."),
+    PDF_PAGE_COUNT_READ_FAILED(HttpStatus.BAD_REQUEST, "PDF 페이지 수를 읽는 중 오류가 발생했습니다."),
+    OCR_PROCESS_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "OCR 처리 중 오류가 발생했습니다."),
+    FILE_STORAGE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 저장 중 오류가 발생했습니다.");
+
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/backend/src/main/java/com/safesign/backend/global/exception/ErrorResponse.java
+++ b/backend/src/main/java/com/safesign/backend/global/exception/ErrorResponse.java
@@ -1,0 +1,16 @@
+package com.safesign.backend.global.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ErrorResponse {
+
+    private final int status;
+    private final String error;
+    private final String message;
+    private final LocalDateTime timestamp;
+}

--- a/backend/src/main/java/com/safesign/backend/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/safesign/backend/global/exception/GlobalExceptionHandler.java
@@ -1,35 +1,41 @@
 package com.safesign.backend.global.exception;
 
-import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.time.LocalDateTime;
-import java.util.Map;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(IllegalArgumentException.class)
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public Map<String, Object> handleIllegalArgumentException(IllegalArgumentException e) {
-        return Map.of(
-                "timestamp", LocalDateTime.now(),
-                "status", 400,
-                "error", "Bad Request",
-                "message", e.getMessage()
-        );
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
+        ErrorCode errorCode = e.getErrorCode();
+
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(
+                        ErrorResponse.builder()
+                                .status(errorCode.getStatus().value())
+                                .error(errorCode.getStatus().name())
+                                .message(errorCode.getMessage())
+                                .timestamp(LocalDateTime.now())
+                                .build()
+                );
     }
 
     @ExceptionHandler(Exception.class)
-    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
-    public Map<String, Object> handleException(Exception e) {
-        return Map.of(
-                "timestamp", LocalDateTime.now(),
-                "status", 500,
-                "error", "Internal Server Error",
-                "message", "서버 내부 오류가 발생했습니다."
-        );
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        return ResponseEntity
+                .internalServerError()
+                .body(
+                        ErrorResponse.builder()
+                                .status(500)
+                                .error("INTERNAL_SERVER_ERROR")
+                                .message("서버 내부 오류가 발생했습니다.")
+                                .timestamp(LocalDateTime.now())
+                                .build()
+                );
     }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -14,5 +14,11 @@ spring:
       hibernate:
         format_sql: true
 
+azure:
+  document-intelligence:
+    endpoint: ${AZURE_DOCUMENT_INTELLIGENCE_ENDPOINT}
+    key: ${AZURE_DOCUMENT_INTELLIGENCE_KEY}
+    model-id: prebuilt-layout
+
 file:
   upload-dir: C:/dev/SafeSign/uploads/contracts


### PR DESCRIPTION
## 🧾 PR 제목
[Feat/#5] Azure OCR 연동 및 OCR 조회 API 구현

---

## 📌 관련 이슈
- Closes #5 

---

## ✨ PR 유형
- [✓] 신규 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명 필요)

---

## 📋 작업 내용
- Azure Document Intelligence 기반 OCR 연동 구현
- OCR 결과 저장 로직 구현
- OCR 조회 API 구현
- OCR 상태 관리 로직 추가
- OCR 예외 처리 및 공통 예외 구조 추가

---

## 🔍 변경 사항
- OCR 엔티티 추가 : OcrResult, OcrPage, OcrLine
- OCR Repository 추가
- OCR 실행 서비스 구현
            Azure OCR 호출
            OCR 결과 저장
            페이지/라인 저장
- OCR 조회 서비스 구현
- OCR API 추가
           POST /api/v1/contracts/{contractId}/ocr
           GET /api/v1/contracts/{contractId}/ocr
- OCR 관련 DTO 추가 : OcrResponse, OcrPageResponse, OcrLineResponse
- 공통 예외 처리 구조 추가 : ErrorCode, CustomException, ErrorResponse, GlobalExceptionHandler

---

## 🧪 테스트
- [✓] 로컬 실행 확인
- [✓] DB 연결 확인
- [✓] API 정상 동작 확인 (Swagger 등)
- [✓] 기타 테스트 : PDF 업로드 테스트
                             OCR 실행 테스트
                             OCR 조회 테스트
                             OCR 예외 응답 테스트

---

## ⚠️ 주의 사항 (중요)
- Azure OCR 환경변수 설정 필요
              azure.document.endpoint(추후 전달)
              azure.document.key(추후 전달)

---

## 📸 스크린샷 (선택)
- UI 변경 시 첨부

---

## 🔗 참고 자료
- 관련 문서 / 링크

---

## 📌 리뷰 요구 사항
- ocr 부분
- global 예외처리 부분

---

## 📌 PR 규칙
- 최소 1명 이상 승인 후 merge
- main 직접 push 금지
- dev 또는 feature 브랜치 사용