### PR TITLE
feat : 계약서 OCR 파싱 구조 개선 및 데이터 분리

### DIFF
--- a/backend/src/main/java/com/safesign/backend/domain/contract/controller/ContractParsingController.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/controller/ContractParsingController.java
@@ -1,0 +1,19 @@
+package com.safesign.backend.domain.contract.controller;
+
+import com.safesign.backend.domain.contract.service.ContractParsingService;
+import com.safesign.backend.domain.contract.dto.response.ParsingResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/contracts")
+public class ContractParsingController {
+
+    private final ContractParsingService parsingService;
+
+    @PostMapping("/{contractId}/parse")
+    public ParsingResponse parseContract(@PathVariable Long contractId) {
+        return parsingService.parse(contractId);
+    }
+}

--- a/backend/src/main/java/com/safesign/backend/domain/contract/dto/response/AgentResponse.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/dto/response/AgentResponse.java
@@ -1,0 +1,13 @@
+package com.safesign.backend.domain.contract.dto.response;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AgentResponse {
+
+    private String officeName;
+    private String address;
+    private String phone;
+    private String licenseNumber;
+}

--- a/backend/src/main/java/com/safesign/backend/domain/contract/dto/response/ClauseResponse.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/dto/response/ClauseResponse.java
@@ -1,0 +1,13 @@
+package com.safesign.backend.domain.contract.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ClauseResponse {
+
+    private String title;
+    private String content;
+    private Integer orderNo;
+}

--- a/backend/src/main/java/com/safesign/backend/domain/contract/dto/response/HeaderResponse.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/dto/response/HeaderResponse.java
@@ -1,0 +1,26 @@
+package com.safesign.backend.domain.contract.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class HeaderResponse {
+
+    private String address;
+    private String landCategory;
+    private String landArea;
+
+    private String buildingStructure;
+    private String buildingUsage;
+    private String buildingArea;
+
+    private String leasedPart;
+    private String leasedArea;
+
+    private String deposit;
+    private String contractAmount;
+    private String middlePayment;
+    private String balance;
+    private String monthlyRent;
+}

--- a/backend/src/main/java/com/safesign/backend/domain/contract/dto/response/ParsingResponse.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/dto/response/ParsingResponse.java
@@ -1,0 +1,21 @@
+package com.safesign.backend.domain.contract.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ParsingResponse {
+
+    private Long contractId;
+    private int clauseCount;
+    private String message;
+
+    private HeaderResponse header;
+    private List<ClauseResponse> clauses;
+    private List<PartyResponse> parties;
+    private List<AgentResponse> agents;
+    private String contractDate;
+}

--- a/backend/src/main/java/com/safesign/backend/domain/contract/dto/response/PartyResponse.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/dto/response/PartyResponse.java
@@ -1,0 +1,19 @@
+package com.safesign.backend.domain.contract.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PartyResponse {
+
+    private String landlordName;
+    private String landlordPhone;
+    private String landlordAddress;
+    private String landlordRRN;
+
+    private String tenantName;
+    private String tenantPhone;
+    private String tenantAddress;
+    private String tenantRRN;
+}

--- a/backend/src/main/java/com/safesign/backend/domain/contract/entity/Contract.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/entity/Contract.java
@@ -8,12 +8,14 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+@Setter
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/backend/src/main/java/com/safesign/backend/domain/contract/entity/ContractClause.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/entity/ContractClause.java
@@ -1,0 +1,28 @@
+package com.safesign.backend.domain.contract.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "contract_clause")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ContractClause {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long clauseId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "contract_id")
+    private Contract contract;
+
+    private String clauseTitle;
+
+    @Column(columnDefinition = "TEXT")
+    private String clauseText;
+
+    private Integer orderNo;
+}

--- a/backend/src/main/java/com/safesign/backend/domain/contract/entity/ContractHeaderInfo.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/entity/ContractHeaderInfo.java
@@ -1,0 +1,66 @@
+package com.safesign.backend.domain.contract.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "contract_header_info")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ContractHeaderInfo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long headerInfoId;
+
+    // 🔗 계약 FK (연관관계)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "contract_id", nullable = false)
+    private Contract contract;
+
+    // 원본 표제부
+    @Column(columnDefinition = "TEXT")
+    private String rawHeader;
+
+    @Column(columnDefinition = "TEXT")
+    private String address;
+
+    @Column(columnDefinition = "TEXT")
+    private String landCategory;
+
+    @Column(columnDefinition = "TEXT")
+    private String landArea;
+
+    @Column(columnDefinition = "TEXT")
+    private String buildingStructure;
+
+    @Column(columnDefinition = "TEXT")
+    private String buildingUsage;
+
+    @Column(columnDefinition = "TEXT")
+    private String buildingArea;
+
+    @Column(columnDefinition = "TEXT")
+    private String leasedPart;
+
+    @Column(columnDefinition = "TEXT")
+    private String leasedArea;
+
+    @Column(columnDefinition = "TEXT")
+    private String deposit;
+
+    @Column(columnDefinition = "TEXT")
+    private String contractAmount;
+
+    @Column(columnDefinition = "TEXT")
+    private String middlePayment;
+
+    @Column(columnDefinition = "TEXT")
+    private String balance;
+
+    @Column(columnDefinition = "TEXT")
+    private String monthlyRent;
+}

--- a/backend/src/main/java/com/safesign/backend/domain/contract/entity/ContractOcrResult.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/entity/ContractOcrResult.java
@@ -1,0 +1,31 @@
+package com.safesign.backend.domain.contract.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+@Entity
+@Table(name = "ocr_result")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ContractOcrResult {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long ocrResultId;
+
+    // 계약서와 연관관계 (FK: contract_id)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "contract_id")
+    private Contract contract;
+
+    // OCR 전체 텍스트
+    @Lob
+    @Basic(fetch = FetchType.LAZY)
+    @JsonIgnore
+    @Column(columnDefinition = "TEXT")
+    private String fullText;
+}

--- a/backend/src/main/java/com/safesign/backend/domain/contract/repository/ContractClauseRepository.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/repository/ContractClauseRepository.java
@@ -1,0 +1,7 @@
+package com.safesign.backend.domain.contract.repository;
+import com.safesign.backend.domain.contract.entity.ContractClause;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface ContractClauseRepository extends JpaRepository<ContractClause, Long> {
+}

--- a/backend/src/main/java/com/safesign/backend/domain/contract/repository/ContractHeaderRepository.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/repository/ContractHeaderRepository.java
@@ -1,0 +1,6 @@
+package com.safesign.backend.domain.contract.repository;
+import com.safesign.backend.domain.contract.entity.ContractHeaderInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ContractHeaderRepository extends JpaRepository<ContractHeaderInfo, Long> {
+}

--- a/backend/src/main/java/com/safesign/backend/domain/contract/repository/ContractOcrResultRepository.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/repository/ContractOcrResultRepository.java
@@ -1,0 +1,12 @@
+package com.safesign.backend.domain.contract.repository;
+
+import com.safesign.backend.domain.contract.entity.ContractOcrResult;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ContractOcrResultRepository extends JpaRepository<ContractOcrResult, Long> {
+
+    // 최신 OCR 결과 가져오기
+    Optional<ContractOcrResult> findTopByContract_ContractIdOrderByOcrResultIdDesc(Long contractId);
+}

--- a/backend/src/main/java/com/safesign/backend/domain/contract/service/ContractParsingService.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/service/ContractParsingService.java
@@ -1,0 +1,297 @@
+package com.safesign.backend.domain.contract.service;
+
+import com.safesign.backend.domain.contract.dto.response.*;
+import com.safesign.backend.domain.contract.entity.Contract;
+import com.safesign.backend.domain.contract.entity.ContractOcrResult;
+import com.safesign.backend.domain.contract.repository.ContractRepository;
+import com.safesign.backend.domain.contract.repository.ContractOcrResultRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.regex.*;
+
+@Service
+@RequiredArgsConstructor
+public class ContractParsingService {
+
+    private final ContractRepository contractRepository;
+    private final ContractOcrResultRepository ocrRepository;
+
+    @Transactional(readOnly = true)
+    public ParsingResponse parse(Long contractId) {
+
+        Contract contract = contractRepository.findById(contractId)
+                .orElseThrow(() -> new RuntimeException("계약 없음"));
+
+        ContractOcrResult ocr = ocrRepository
+                .findTopByContract_ContractIdOrderByOcrResultIdDesc(contractId)
+                .orElseThrow(() -> new RuntimeException("OCR 없음"));
+
+        String text = preprocess(ocr.getFullText());
+
+        List<String> lines = toLines(text);
+        List<String> headerLines = extractHeaderLines(lines);
+
+        HeaderResponse header = parseHeader(headerLines);
+        List<ClauseResponse> clauses = parseClauses(text);
+        List<PartyResponse> parties = parseParties(lines);
+        List<AgentResponse> agents = parseAgents(lines);
+        String contractDate = extractContractDate(text);
+
+        return new ParsingResponse(
+                contractId,
+                clauses.size(),
+                "파싱 완료",
+                header,
+                clauses,
+                parties,
+                agents,
+                contractDate
+        );
+    }
+
+    // =====================
+    // 전처리
+    // =====================
+    private String preprocess(String text) {
+        return text
+                .replaceAll(":unselected:", "")
+                .replaceAll("\\r", "")
+
+                .replaceAll("건\\s*물", "건물")
+                .replaceAll("토\\s*지", "토지")
+                .replaceAll("구\\s*조", "구조")
+                .replaceAll("용\\s*도", "용도")
+
+                .replaceAll("(제\\d+조)", "\n$1\n")
+
+                // 숫자 노이즈 제거
+                .replaceAll("(\\d+\\.\\d+)", "")
+                .replaceAll("(\\d{3,}\\.)", "")
+
+                .replaceAll("\\n+", "\n")
+                .trim();
+    }
+
+    private List<String> toLines(String text) {
+        return Arrays.stream(text.split("\n"))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList();
+    }
+
+    // =====================
+    // HEADER 분리
+    // =====================
+    private List<String> extractHeaderLines(List<String> lines) {
+        List<String> header = new ArrayList<>();
+        for (String line : lines) {
+            if (line.matches("제\\d+조.*")) break;
+            header.add(line);
+        }
+        return header;
+    }
+
+    // =====================
+    // HEADER 파싱
+    // =====================
+    private HeaderResponse parseHeader(List<String> lines) {
+
+        String address = null;
+        String landCategory = null;
+        String landArea = null;
+        String buildingStructure = null;
+        String buildingUsage = null;
+        String buildingArea = null;
+        String leasedPart = null;
+        String leasedArea = null;
+
+        for (int i = 0; i < lines.size(); i++) {
+
+            String line = lines.get(i);
+
+            if (line.equals("소재지")) address = safe(lines, i + 1);
+
+            if (line.contains("지목"))
+                landCategory = line.replaceAll("[^가-힣]", "");
+
+            if (line.equals("면적") && landArea == null)
+                landArea = safe(lines, i + 1);
+
+            if (line.equals("구조"))
+                buildingStructure = safe(lines, i + 1);
+
+            if (line.equals("용도")) {
+                String next = safe(lines, i + 1);
+                if (next != null && !next.matches("제\\d+조.*")) {
+                    buildingUsage = next;
+                }
+            }
+
+            if (line.equals("면적") && i > 0 && lines.get(i - 1).contains("용도")) {
+                buildingArea = safe(lines, i + 1);
+            }
+
+            if (line.contains("임대부분"))
+                leasedPart = line.replace("임대부분", "").trim();
+
+            if (line.contains("약") && line.contains("m2"))
+                leasedArea = line;
+        }
+
+        return new HeaderResponse(
+                address,
+                landCategory,
+                landArea,
+                buildingStructure,
+                buildingUsage,
+                buildingArea,
+                leasedPart,
+                leasedArea,
+                null, null, null, null, null
+        );
+    }
+
+    // =====================
+    // 🔥 조항 파싱 (핵심)
+    // =====================
+    private List<ClauseResponse> parseClauses(String text) {
+
+        List<ClauseResponse> result = new ArrayList<>();
+        int order = 1;
+
+        String[] parts = text.split("특약사항");
+        String body = parts[0];
+        String special = parts.length > 1 ? parts[1] : "";
+
+        // 제N조
+        Pattern p = Pattern.compile("(제\\d+조)(.*?)(?=제\\d+조|$)", Pattern.DOTALL);
+        Matcher m = p.matcher(body);
+
+        while (m.find()) {
+            result.add(new ClauseResponse(
+                    m.group(1),
+                    m.group(2).trim(),
+                    order++
+            ));
+        }
+
+        // 특약
+        Pattern sp = Pattern.compile("(\\d+\\.)(.*?)(?=\\d+\\.|$)", Pattern.DOTALL);
+        Matcher sm = sp.matcher(special);
+
+        while (sm.find()) {
+
+            String title = sm.group(1);
+            String content = sm.group(2).trim();
+
+            // 🔥 6번에서 하단 제거
+            if (title.equals("6.")) {
+                int idx = content.indexOf("임대인");
+                if (idx > 0) {
+                    content = content.substring(0, idx);
+                }
+            }
+
+            if (content.length() < 10) continue;
+
+            result.add(new ClauseResponse(title, content, order++));
+        }
+
+        return result;
+    }
+
+    // =====================
+    // 당사자
+    // =====================
+    private List<PartyResponse> parseParties(List<String> lines) {
+
+        String landlordName = null, landlordPhone = null, landlordAddress = null, landlordRRN = null;
+        String tenantName = null, tenantPhone = null, tenantAddress = null, tenantRRN = null;
+
+        for (int i = 0; i < lines.size(); i++) {
+
+            if (lines.get(i).contains("임대인")) {
+                landlordName = findNext(lines, i, "성 명");
+                landlordPhone = findPhone(lines, i);
+                landlordAddress = findNext(lines, i, "주 소");
+                landlordRRN = findRRN(lines, i);
+            }
+
+            if (lines.get(i).contains("임차인")) {
+                tenantName = findNext(lines, i, "성 명");
+                tenantPhone = findPhone(lines, i);
+                tenantAddress = findNext(lines, i, "주 소");
+                tenantRRN = findRRN(lines, i);
+            }
+        }
+
+        return List.of(new PartyResponse(
+                landlordName, landlordPhone, landlordAddress, landlordRRN,
+                tenantName, tenantPhone, tenantAddress, tenantRRN
+        ));
+    }
+
+    // =====================
+    // 중개사
+    // =====================
+    private List<AgentResponse> parseAgents(List<String> lines) {
+
+        List<AgentResponse> list = new ArrayList<>();
+
+        for (int i = 0; i < lines.size(); i++) {
+            if (lines.get(i).contains("공인중개사")) {
+
+                list.add(new AgentResponse(
+                        findNext(lines, i, "사무소 명칭"),
+                        findNext(lines, i, "소재지"),
+                        findPhone(lines, i),
+                        findNext(lines, i, "등록 번 호")
+                ));
+            }
+        }
+
+        return list;
+    }
+
+    private String extractContractDate(String text) {
+        Matcher m = Pattern.compile("\\d{4}년\\s*\\d{2}월\\s*\\d{2}일").matcher(text);
+        return m.find() ? m.group() : null;
+    }
+
+    // =====================
+    // 유틸
+    // =====================
+    private String safe(List<String> lines, int idx) {
+        return idx < lines.size() ? lines.get(idx) : null;
+    }
+
+    private String findNext(List<String> lines, int start, String key) {
+        for (int i = start; i < lines.size(); i++) {
+            if (lines.get(i).contains(key) && i + 1 < lines.size()) {
+                return lines.get(i + 1);
+            }
+        }
+        return null;
+    }
+
+    private String findPhone(List<String> lines, int start) {
+        for (int i = start; i < lines.size(); i++) {
+            if (lines.get(i).matches("010-\\d{4}-\\d{4}")) {
+                return lines.get(i);
+            }
+        }
+        return null;
+    }
+
+    private String findRRN(List<String> lines, int start) {
+        for (int i = start; i < lines.size(); i++) {
+            if (lines.get(i).matches("\\d{6}-\\d{7}")) {
+                return lines.get(i);
+            }
+        }
+        return null;
+    }
+}

--- a/backend/src/main/java/com/safesign/backend/domain/ocr/entity/OcrResult.java
+++ b/backend/src/main/java/com/safesign/backend/domain/ocr/entity/OcrResult.java
@@ -34,7 +34,7 @@ public class OcrResult {
     @Column(nullable = false, length = 30)
     private OcrStatus status;
 
-    @Lob
+    @Column(columnDefinition = "TEXT")
     private String fullText;
 
     @Lob

--- a/backend/src/main/java/com/safesign/backend/global/RootController.java
+++ b/backend/src/main/java/com/safesign/backend/global/RootController.java
@@ -1,0 +1,14 @@
+package com.safesign.backend.global;
+
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class RootController {
+
+    @GetMapping("/")
+    public String home() {
+        return "SafeSign Backend Running";
+    }
+}

--- a/backend/src/main/java/com/safesign/backend/global/config/CorsConfig.java
+++ b/backend/src/main/java/com/safesign/backend/global/config/CorsConfig.java
@@ -1,0 +1,24 @@
+package com.safesign.backend.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**")
+                        .allowedOrigins("*")
+                        .allowedMethods("*")
+                        .allowedHeaders("*");
+            }
+        };
+    }
+}

--- a/backend/src/main/java/com/safesign/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/safesign/backend/global/config/SecurityConfig.java
@@ -12,6 +12,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
+                .cors(Customizer.withDefaults())
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(

--- a/backend/src/main/java/com/safesign/backend/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/safesign/backend/global/exception/GlobalExceptionHandler.java
@@ -27,13 +27,16 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleException(Exception e) {
+
+        e.printStackTrace(); // 🔥 콘솔에 진짜 에러 출력
+
         return ResponseEntity
                 .internalServerError()
                 .body(
                         ErrorResponse.builder()
                                 .status(500)
                                 .error("INTERNAL_SERVER_ERROR")
-                                .message("서버 내부 오류가 발생했습니다.")
+                                .message(e.getMessage())
                                 .timestamp(LocalDateTime.now())
                                 .build()
                 );

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -7,12 +7,17 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: none
     show-sql: true
     open-in-view: false
     properties:
       hibernate:
         format_sql: true
+
+  servlet:
+    multipart:
+      max-file-size: 50MB
+      max-request-size: 50MB
 
 azure:
   document-intelligence:
@@ -21,4 +26,4 @@ azure:
     model-id: prebuilt-layout
 
 file:
-  upload-dir: C:/dev/SafeSign/uploads/contracts
+  upload-dir: ${FILE_UPLOAD_DIR}


### PR DESCRIPTION
## 🧾 PR 제목
[Feat/#7] 계약서 OCR 파싱 구조 개선 및 데이터 분리

---

## 📌 관련 이슈
- Closes #7

---

## ✨ PR 유형
- [x] 신규 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명 필요)

---

## 📋 작업 내용
- OCR 텍스트 기반 계약서 파싱 로직 구현
- 제N조 조항 자동 분리 기능 구현
- 특약사항(1~6) 개별 파싱 처리
- 특약 6번 내부의 당사자/서명 영역 제거 및 분리
- 임대인 / 임차인 정보 파싱 (이름, 전화번호, 주소, 주민번호)
- 공인중개사 정보 파싱 추가
- 계약 날짜 추출 기능 구현
- OCR 노이즈 제거 및 전처리 로직 개선

---

## 🔍 변경 사항
- 핵심 변경 로직
- 추가/수정된 파일
- DB / API / 설정 변경 여부

---

## 🧪 테스트
- [x] 로컬 실행 확인
- [x] DB 연결 확인
- [x] API 정상 동작 확인 (Swagger)
- [x] 계약서 OCR 텍스트 파싱 결과 확인

---

## ⚠️ 주의 사항 (중요)
- 환경변수 변경 여부
- DB 구조 변경 여부
- 팀원에게 영향 있는 부분

---

## 📸 스크린샷 (선택)
<img width="2125" height="696" alt="image" src="https://github.com/user-attachments/assets/8ecbc1fe-110b-4af8-a1e1-4b3993bac261" />

---

## 🔗 참고 자료


---

## 📌 리뷰 요구 사항
- 집중적으로 봐야 할 부분
- 고민했던 부분

---

## 📌 PR 규칙
- 최소 1명 이상 승인 후 merge
- main 직접 push 금지
- dev 또는 feature 브랜치 사용