### PR TITLE
bug: ocr_result TEXT 컬럼 매핑 오류 수정

### DIFF
--- a/backend/src/main/java/com/safesign/backend/domain/contract/entity/ContractOcrResult.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/entity/ContractOcrResult.java
@@ -23,9 +23,7 @@ public class ContractOcrResult {
     private Contract contract;
 
     // OCR 전체 텍스트
-    @Lob
-    @Basic(fetch = FetchType.LAZY)
     @JsonIgnore
-    @Column(columnDefinition = "TEXT")
+    @Column(name = "full_text", columnDefinition = "TEXT")
     private String fullText;
 }

--- a/backend/src/main/java/com/safesign/backend/domain/ocr/entity/OcrResult.java
+++ b/backend/src/main/java/com/safesign/backend/domain/ocr/entity/OcrResult.java
@@ -34,10 +34,10 @@ public class OcrResult {
     @Column(nullable = false, length = 30)
     private OcrStatus status;
 
-    @Column(columnDefinition = "TEXT")
+    @Column(name = "full_text", columnDefinition = "TEXT")
     private String fullText;
 
-    @Lob
+    @Column(columnDefinition = "TEXT")
     private String rawJson;
 
     private LocalDateTime startedAt;


### PR DESCRIPTION
## 🧾 PR 제목
[Bug/#12] ocr_result full_text/raw_json 타입 문제 해결

- OCR 결과 저장 및 조회 시 발생하던 타입 mismatch 오류 해결
---

## 📌 관련 이슈
- Closes #12 

---

## ✨ PR 유형
- [ ] 신규 기능
- [0] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명 필요)

---

## 📋 작업 내용
- `@Lob` 제거 및 TEXT 타입으로 매핑 수정
  - `OcrResult.fullText`(Entity)
  - `OcrResult.rawJson`(Entity)
  - `ContractOcrResult.fullText`(Entity)

---

## 🔍 변경 사항
- PostgreSQL 컬럼 타입 수정
  - `full_text`: oid → text
  - `raw_json`: oid → text

---

## 🧪 테스트
- [0] 로컬 실행 확인
- [0] DB 연결 확인
- [0] API 정상 동작 확인 (Swagger 등)
- [ ] 기타 테스트:

---

## ⚠️ 주의 사항 (중요)
- DB 구조 변경 여부 있음

---

## 📸 스크린샷 (선택)
- UI 변경 시 첨부

---

## 🔗 참고 자료
- 관련 문서 / 링크

---

## 📌 리뷰 요구 사항
- 집중적으로 봐야 할 부분
- 고민했던 부분

---

## 📌 PR 규칙
- 최소 1명 이상 승인 후 merge
- main 직접 push 금지
- dev 또는 feature 브랜치 사용