### PR TITLE
refactor: improve oauth2 success handling

### DIFF
--- a/backend/src/main/java/com/safesign/backend/domain/auth/oauth/OAuth2SuccessHandler.java
+++ b/backend/src/main/java/com/safesign/backend/domain/auth/oauth/OAuth2SuccessHandler.java
@@ -3,7 +3,7 @@ package com.safesign.backend.domain.auth.oauth;
 import com.safesign.backend.domain.auth.service.RefreshTokenService;
 import com.safesign.backend.global.auth.jwt.JwtTokenProvider;
 import jakarta.servlet.ServletException;
-import jakarta.servlet.http.Cookie;
+import org.springframework.http.ResponseCookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +11,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
+import org.springframework.beans.factory.annotation.Value;
 
 import java.io.IOException;
 
@@ -20,6 +21,15 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenService refreshTokenService;
+
+    @Value("${app.frontend-url}")
+    private String frontendUrl;
+
+    @Value("${app.cookie.secure}")
+    private boolean cookieSecure;
+
+    @Value("${app.cookie.same-site}")
+    private String cookieSameSite;
 
     @Override
     public void onAuthenticationSuccess(
@@ -32,7 +42,6 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
         Long userId = Long.valueOf(oauth2User.getName());
 
-        String accessToken = jwtTokenProvider.createAccessToken(userId);
         String refreshToken = jwtTokenProvider.createRefreshToken(userId);
 
         refreshTokenService.saveRefreshToken(
@@ -41,18 +50,16 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
                 jwtTokenProvider.getRefreshTokenExpiration()
         );
 
-        Cookie refreshTokenCookie = new Cookie("refreshToken", refreshToken);
-        refreshTokenCookie.setHttpOnly(true);
-        refreshTokenCookie.setSecure(false); // 로컬은 false, 배포 HTTPS는 true
-        refreshTokenCookie.setPath("/");
-        refreshTokenCookie.setMaxAge((int) (jwtTokenProvider.getRefreshTokenExpiration() / 1000));
+        ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", refreshToken)
+                .httpOnly(true)
+                .secure(false) // 로컬 false, 배포 HTTPS true
+                .path("/")
+                .sameSite("Lax") // 로컬은 Lax 권장, 배포 시 None
+                .maxAge(jwtTokenProvider.getRefreshTokenExpiration() / 1000)
+                .build();
 
-        response.addCookie(refreshTokenCookie);
+        response.addHeader("Set-Cookie", refreshTokenCookie.toString());
 
-        response.setContentType("application/json");
-        response.setCharacterEncoding("UTF-8");
-
-        String body = "{\"accessToken\": \"" + accessToken + "\"}";
-        response.getWriter().write(body);
+        response.sendRedirect(frontendUrl + "/oauth/success");
     }
 }

--- a/backend/src/main/java/com/safesign/backend/global/auth/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/safesign/backend/global/auth/jwt/JwtAuthenticationFilter.java
@@ -31,24 +31,41 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         String token = resolveToken(request);
 
-        if (token != null && jwtTokenProvider.validateToken(token)) {
-            Long userId = jwtTokenProvider.getUserId(token);
-
-            User user = userRepository.findById(userId).orElse(null);
-
-            if (user != null) {
-                CustomUserDetails userDetails = new CustomUserDetails(user);
-
-                UsernamePasswordAuthenticationToken authentication =
-                        new UsernamePasswordAuthenticationToken(
-                                userDetails,
-                                null,
-                                userDetails.getAuthorities()
-                        );
-
-                SecurityContextHolder.getContext().setAuthentication(authentication);
-            }
+        if (token == null) {
+            filterChain.doFilter(request, response);
+            return;
         }
+
+        if (!jwtTokenProvider.validateToken(token)) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.setContentType("application/json");
+            response.setCharacterEncoding("UTF-8");
+            response.getWriter().write("{\"message\":\"Invalid or expired token\"}");
+            return;
+        }
+
+        Long userId = jwtTokenProvider.getUserId(token);
+
+        User user = userRepository.findById(userId).orElse(null);
+
+        if (user == null) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.setContentType("application/json");
+            response.setCharacterEncoding("UTF-8");
+            response.getWriter().write("{\"message\":\"User not found\"}");
+            return;
+        }
+
+        CustomUserDetails userDetails = new CustomUserDetails(user);
+
+        UsernamePasswordAuthenticationToken authentication =
+                new UsernamePasswordAuthenticationToken(
+                        userDetails,
+                        null,
+                        userDetails.getAuthorities()
+                );
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
 
         filterChain.doFilter(request, response);
     }

--- a/backend/src/main/java/com/safesign/backend/global/config/CorsConfig.java
+++ b/backend/src/main/java/com/safesign/backend/global/config/CorsConfig.java
@@ -1,5 +1,6 @@
 package com.safesign.backend.global.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
@@ -8,6 +9,9 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class CorsConfig {
 
+    @Value("${app.frontend-url}")
+    private String frontendUrl;
+
     @Bean
     public WebMvcConfigurer corsConfigurer() {
         return new WebMvcConfigurer() {
@@ -15,9 +19,10 @@ public class CorsConfig {
             @Override
             public void addCorsMappings(CorsRegistry registry) {
                 registry.addMapping("/**")
-                        .allowedOrigins("*")
-                        .allowedMethods("*")
-                        .allowedHeaders("*");
+                        .allowedOrigins(frontendUrl)
+                        .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+                        .allowedHeaders("*")
+                        .allowCredentials(true);
             }
         };
     }

--- a/backend/src/main/java/com/safesign/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/safesign/backend/global/config/SecurityConfig.java
@@ -63,17 +63,17 @@ public class SecurityConfig {
 
                                 "/favicon.ico",
 
-                                "/auth/reissue",
+                                "/api/v1/auth/reissue",
 
                                 "/api/v1/admin/auth/**"
                         ).permitAll()
 
                         // 관리자 전용
-                        .requestMatchers("/api/admin/**")
+                        .requestMatchers("/api/v1/admin/**")
                         .authenticated()
 
                         // 로그인 사용자
-                        .requestMatchers("/api/v1/auth/me")
+                        .requestMatchers("/api/v1/auth/**")
                         .authenticated()
 
                         .requestMatchers("/api/v1/contracts/**")

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -68,3 +68,10 @@ jwt:
   secret: ${JWT_SECRET}
   access-token-expiration: ${JWT_ACCESS_TOKEN_EXPIRATION:3600000}
   refresh-token-expiration: ${JWT_REFRESH_TOKEN_EXPIRATION:1209600000}
+
+app:
+  frontend-url: ${FRONTEND_URL:http://localhost:3000}
+
+  cookie:
+    secure: ${COOKIE_SECURE:false}
+    same-site: ${COOKIE_SAME_SITE:Lax}


### PR DESCRIPTION
## 🧾 PR 제목
[Feat/#20] OAuth2 인증 흐름 및 쿠키 기반 인증 구조 개선


---

## 📌 관련 이슈
- Closes #20

---

## ✨ PR 유형
- [0] 리팩토링


---

## 📋 작업 내용
- 기존 JSON 응답 방식 대신 프론트엔드 성공 페이지로 redirect하는 구조로 변경
- refreshToken Cookie의 Secure / SameSite 정책을 환경변수 기반으로 분리

---

## 🔍 변경 사항
- OAuth2SuccessHandler
   - accessToken JSON 응답 제거
   - refreshToken Cookie 저장 후 프론트 redirect 방식으로 변경
- CorsConfig
   - frontend-url 환경변수 기반 설정 적용
   - allowCredentials(true) 추가
- application.yml
   - frontend-url / cookie secure / same-site 설정 추가

---

## 🧪 테스트
- [0] 로컬 실행 확인
- [0] DB 연결 확인
- [0] API 정상 동작 확인 (Swagger 등)
- [ ] 기타 테스트:

---

## ⚠️ 주의 사항 (중요)
- 환경변수 변경 여부 있음

---

## 📸 스크린샷 (선택)
- UI 변경 시 첨부

---

## 🔗 참고 자료
- 관련 문서 / 링크

---

## 📌 리뷰 요구 사항
- 집중적으로 봐야 할 부분
- 고민했던 부분

---

## 📌 PR 규칙
- 최소 1명 이상 승인 후 merge
- main 직접 push 금지
- dev 또는 feature 브랜치 사용