### PR TITLE
refactor : 문장 분리 및 조항 분리 구조 개선

### DIFF
--- a/backend/src/main/java/com/safesign/backend/domain/contract/dto/response/ParsingResponse.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/dto/response/ParsingResponse.java
@@ -13,9 +13,19 @@ public class ParsingResponse {
     private int clauseCount;
     private String message;
 
-    private HeaderResponse header;
+    // OCR 텍스트를 줄 단위로 분리한 전체 문장 리스트
+    private List<String> lines;
+
+    // 분리된 조항(제N조, 특약사항) 리스트
     private List<ClauseResponse> clauses;
-    private List<PartyResponse> parties;
-    private List<AgentResponse> agents;
-    private String contractDate;
+
+    // 좌표 기반 추출 로직 도입 -> 표제부 추출
+    private HeaderResponse header;
+
+    // ---------------------------------------------------------
+    // 아직 복구하지 않은 당사자, 중개사, 계약일 등은 삭제 유지
+    // ---------------------------------------------------------
+    // private List<PartyResponse> parties;
+    // private List<AgentResponse> agents;
+    // private String contractDate;
 }

--- a/backend/src/main/java/com/safesign/backend/domain/contract/service/ContractParsingService.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/service/ContractParsingService.java
@@ -6,6 +6,7 @@ import com.safesign.backend.domain.contract.repository.*;
 import com.safesign.backend.global.exception.CustomException;
 import com.safesign.backend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,7 +14,9 @@ import java.math.BigDecimal;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -21,573 +24,202 @@ public class ContractParsingService {
 
     private final ContractRepository contractRepository;
     private final ContractOcrResultRepository ocrRepository;
-
     private final ContractClauseRepository clauseRepository;
     private final ContractHeaderInfoRepository headerRepository;
 
     public ParsingResponse parse(Long userId, Long contractId) {
 
-        // 계약 조회
+        // 1. 계약 및 OCR 조회
         Contract contract = contractRepository
                 .findByContractIdAndUser_UserId(contractId, userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.CONTRACT_NOT_FOUND));
 
-        // OCR 조회
         ContractOcrResult ocr = ocrRepository
                 .findLatestOcrResult(contract)
                 .orElseThrow(() -> new CustomException(ErrorCode.OCR_RESULT_NOT_FOUND));
 
-        // OCR 전처리
-        String text = preprocess(ocr.getFullText());
+        // 2. OCR 텍스트 전처리 및 줄 단위 분리
+        String cleanText = preprocess(ocr.getFullText());
+        List<String> lines = Arrays.stream(cleanText.split("\n"))
+                .map(String::trim)
+                .filter(line -> !line.isEmpty())
+                .collect(Collectors.toList());
 
-        String[] lines = text.split("\n");
-
-        // 기존 데이터 삭제
+        // 3. 기존 데이터 초기화 (조항 & 표제부)
         clauseRepository.deleteByContract(contract);
         headerRepository.deleteByContract(contract);
 
-        // HEADER
-        HeaderResponse header = extractHeaderInfo(lines);
+        // 4. 조항 단위 분리 및 엔티티 저장
+        List<ClauseResponse> clauses = extractClauses(cleanText);
 
-        // 당사자
-        List<PartyResponse> parties = extractParties(lines);
-
-        // HEADER 저장
-        ContractHeaderInfo headerEntity = ContractHeaderInfo.builder()
-                .contract(contract)
-
-                .landlordName(
-                        parties.isEmpty()
-                                ? null
-                                : parties.get(0).getLandlordName()
-                )
-
-                .propertyAddress(header.getAddress())
-
-                .propertyArea(parseArea(header.getLeasedArea()))
-
-                .depositAmount(parseMoney(header.getDeposit()))
-
-                .monthlyRent(parseMoney(header.getMonthlyRent()))
-
-                .contractPayment(parseMoney(header.getContractAmount()))
-
-                .intermediatePayment(parseMoney(header.getMiddlePayment()))
-
-                .balancePayment(parseMoney(header.getBalance()))
-
-                .brokerFee(extractBrokerFee(text))
-
-                .build();
-
-        headerRepository.save(headerEntity);
-
-        // 조항 파싱
-        List<ClauseResponse> clauses = extractClauses(text);
-
-        // 저장
         for (ClauseResponse clause : clauses) {
-
             String clauseNo = normalizeClauseNo(clause.getTitle());
 
             ContractClause entity = ContractClause.builder()
                     .contract(contract)
-
                     .clauseNo(clauseNo)
-
                     .clauseTitle(clause.getTitle())
-
                     .clauseText(clause.getContent())
-
-                    .clauseType(
-                            clauseNo.startsWith("제")
-                                    ? "STANDARD"
-                                    : "SPECIAL"
-                    )
-
+                    .clauseType(clauseNo.startsWith("제") ? "STANDARD" : "SPECIAL")
                     .orderNo(clause.getOrderNo())
-
                     .build();
 
             clauseRepository.save(entity);
         }
 
-        // 중개사
-        List<AgentResponse> agents = extractAgents(lines);
+        // 5. 표제부(Header) 추출
+        HeaderResponse header = extractHeaderInfo(lines);
 
-        // 계약일
-        String contractDate = extractContractDate(text);
+        // 6. 표제부(Header)
+        ContractHeaderInfo headerEntity = ContractHeaderInfo.builder()
+                .contract(contract)
+                .propertyAddress(header.getAddress())
+                .depositAmount(parseMoney(header.getDeposit()))
+                .contractPayment(parseMoney(header.getContractAmount()))
+                .monthlyRent(parseMoney(header.getMonthlyRent()))
+                // 아래 항목들은 현재 정규식으로 완벽히 뽑기 어려워 null로 들어갈 수 있음
+                .propertyArea(null)
+                .intermediatePayment(null)
+                .balancePayment(null)
+                .brokerFee(null)
+                .landlordName(null)
+                .build();
 
+        headerRepository.save(headerEntity);
+
+        // 7. 결과 반환
         return new ParsingResponse(
                 contract.getContractId(),
                 clauses.size(),
-                "파싱 완료",
-                header,
+                "파싱 및 저장 완료",
+                lines,
                 clauses,
-                parties,
-                agents,
-                contractDate
+                header
         );
     }
 
-    // =====================================================
-    // OCR 전처리
-    // =====================================================
-
+    // OCR 전처리 (노이즈 제거)
     private String preprocess(String text) {
-
         return text
-
-                .replaceAll(":selected:", "")
-                .replaceAll(":unselected:", "")
-
-                .replaceAll("\\[V]", "")
-                .replaceAll("\\[√]", "")
-
-                .replaceAll("건\\s*물", "건물")
-                .replaceAll("소\\s*재\\s*지", "소재지")
-
-                .replaceAll("계\\s*약\\s*금", "계약금")
-                .replaceAll("중\\s*도\\s*금", "중도금")
-                .replaceAll("잔\\s*금", "잔금")
-                .replaceAll("차\\s*임", "차임")
-
+                .replaceAll(":(un)?selected:", "")
+                .replaceAll("\\[[V√]]", "")
                 .replaceAll("\\r", "")
-
                 .replaceAll("\\n+", "\n")
-
                 .trim();
     }
 
-    // =====================================================
-    // HEADER 추출
-    // =====================================================
-
-    private HeaderResponse extractHeaderInfo(String[] lines) {
-
-        StringBuilder builder = new StringBuilder();
+    // 표제부(Header) 추출 (주소, 보증금, 월세, 계약금)
+    private HeaderResponse extractHeaderInfo(List<String> lines) {
+        String address = null, deposit = null, monthlyRent = null, contractAmount = null;
 
         for (String line : lines) {
-
-            builder.append(line).append(" ");
+            if (line.contains("소재지") || line.contains("부동산의 표시")) {
+                address = line.replaceAll("소재지|1\\.\\s*부동산의 표시", "").trim();
+            }
+            if (line.contains("보증금")) {
+                deposit = extractMoneyStr(line);
+            }
+            if (line.contains("차 임") || line.contains("차임")) {
+                monthlyRent = extractMoneyStr(line);
+            }
+            if (line.contains("계약금")) {
+                contractAmount = extractMoneyStr(line);
+            }
         }
-
-        String fullText = builder.toString();
-
-        String address = null;
-
-        String deposit = null;
-
-        String monthlyRent = null;
-
-        String contractAmount = null;
-
-        String middlePayment = null;
-
-        String balance = null;
-
-        String leasedArea = null;
-
-        // 주소
-        Matcher addressMatcher = Pattern.compile(
-                "소재지\\s*([가-힣0-9\\-\\s]+(?:번지|로|길).*?\\d+)"
-        ).matcher(fullText);
-
-        if (addressMatcher.find()) {
-
-            address = addressMatcher.group(1)
-                    .replaceAll("\\s+", " ")
-                    .trim();
-        }
-
-        // 면적
-        Matcher areaMatcher = Pattern.compile(
-                "약\\s*(\\d+)\\s*m2"
-        ).matcher(fullText);
-
-        if (areaMatcher.find()) {
-
-            leasedArea = "약 " + areaMatcher.group(1) + " m2";
-        }
-
-        // 보증금
-        Matcher depositMatcher = Pattern.compile(
-                "보증금.*?(₩?[\\d,]+)"
-        ).matcher(fullText);
-
-        if (depositMatcher.find()) {
-
-            deposit = depositMatcher.group(1);
-        }
-
-        // 월세
-        Matcher rentMatcher = Pattern.compile(
-                "차임.*?(₩?[\\d,]+)"
-        ).matcher(fullText);
-
-        if (rentMatcher.find()) {
-
-            monthlyRent = rentMatcher.group(1);
-        }
-
-        // 계약금
-        Matcher contractMatcher = Pattern.compile(
-                "계약금.*?(₩?[\\d,]+)"
-        ).matcher(fullText);
-
-        if (contractMatcher.find()) {
-
-            contractAmount = contractMatcher.group(1);
-        }
-
-        // 중도금
-        Matcher middleMatcher = Pattern.compile(
-                "중도금.*?(₩?[\\d,]+)"
-        ).matcher(fullText);
-
-        if (middleMatcher.find()) {
-
-            middlePayment = middleMatcher.group(1);
-        }
-
-        // 잔금
-        Matcher balanceMatcher = Pattern.compile(
-                "잔금.*?(₩?[\\d,]+)"
-        ).matcher(fullText);
-
-        if (balanceMatcher.find()) {
-
-            balance = balanceMatcher.group(1);
-        }
-
-        return new HeaderResponse(
-                address,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                leasedArea,
-                deposit,
-                contractAmount,
-                middlePayment,
-                balance,
-                monthlyRent
-        );
+        return new HeaderResponse(address, null, null, null, null, null, null, null, deposit, contractAmount, null, null, monthlyRent);
     }
 
-    // =====================================================
-    // 조항 추출
-    // =====================================================
+    // 문자열 금액 추출
+    private String extractMoneyStr(String line) {
+        Matcher m = Pattern.compile("[₩\\\\]?\\s*([0-9,]+)").matcher(line);
+        if (m.find()) {
+            return m.group(1);
+        }
+        return null;
+    }
+
+    // 숫자 금액 파싱
+    private Long parseMoney(String value) {
+        if (value == null) return null;
+        String onlyNumber = value.replaceAll("[^0-9]", "");
+        if (onlyNumber.isBlank()) return null;
+        return Long.parseLong(onlyNumber);
+    }
+
+    // 조항 추출 (제N조 및 특약사항)
 
     private List<ClauseResponse> extractClauses(String text) {
-
         List<ClauseResponse> clauses = new ArrayList<>();
-
-        Pattern clausePattern = Pattern.compile(
-                "(제\\d+조)\\)?\\s*\\[([^\\]]+)]\\s*(.*?)(?=제\\d+조\\)|특약사항|$)",
-                Pattern.DOTALL
-        );
-
-        Matcher matcher = clausePattern.matcher(text);
-
         int orderNo = 1;
 
+        Pattern clausePattern = Pattern.compile(
+                "([제체]\\s*\\d+\\s*조)[).]?\\s*[(\\[【<]([^)\\]】>]+)[)\\]】>]\\s*(.*?)(?=[제체]\\s*\\d+\\s*조|특\\s*약|본\\s*계약|$)",
+                Pattern.DOTALL
+        );
+        Matcher matcher = clausePattern.matcher(text);
+
         while (matcher.find()) {
+            String clauseNo = matcher.group(1).replaceAll("\\s+", "").replace("체", "제");
+            String title = matcher.group(2).replaceAll("\\s+", " ").trim();
+            String content = matcher.group(3).replaceAll("\\s+", " ").trim();
 
-            String clauseNo = matcher.group(1);
-
-            String title = matcher.group(2)
-                    .replaceAll("\\s+", " ")
-                    .trim();
-
-            String content = matcher.group(3)
-                    .replaceAll("\\s+", " ")
-                    .trim();
-
-            if (content.length() < 5) {
-                continue;
+            if (content.length() >= 5) {
+                clauses.add(new ClauseResponse(clauseNo + " [" + title + "]", content, orderNo++));
             }
-
-            clauses.add(
-                    new ClauseResponse(
-                            clauseNo + " [" + title + "]",
-                            content,
-                            orderNo++
-                    )
-            );
         }
 
-        // 특약사항
         List<String> specialTerms = extractSpecialTerms(text);
-
         for (String special : specialTerms) {
-
-            clauses.add(
-                    new ClauseResponse(
-                            "특약사항",
-                            special,
-                            orderNo++
-                    )
-            );
+            clauses.add(new ClauseResponse("특약사항", special, orderNo++));
         }
 
         return clauses;
     }
 
-    // =====================================================
-    // 특약사항
-    // =====================================================
-
+    // 특약사항 세부 문장 추출
     private List<String> extractSpecialTerms(String text) {
-
         List<String> result = new ArrayList<>();
-
         String[] lines = text.split("\n");
+        boolean isSpecialSection = false;
 
-        boolean specialStart = false;
+        Pattern startPattern = Pattern.compile("특\\s*약\\s*사\\s*항|특\\s*약\\s*조\\s*건|특\\s*수\\s*조\\s*건|특\\s*약|\\[\\s*특\\s*약\\s*]");
+        Pattern endPattern = Pattern.compile("^\\s*(본\\s*계약에|위와\\s*같이|계약을\\s*체결|\\d{4}년\\s*\\d{1,2}월|임\\s*대\\s*인\\s*$|매\\s*도\\s*인\\s*$|임\\s*차\\s*인\\s*$)");
 
         for (String line : lines) {
+            String trimmedLine = line.trim();
+            if (trimmedLine.isEmpty()) continue;
 
-            line = line.trim();
-
-            if (line.contains("특약사항")) {
-
-                specialStart = true;
-
+            if (!isSpecialSection && startPattern.matcher(trimmedLine).find()) {
+                isSpecialSection = true;
                 continue;
             }
 
-            if (!specialStart) {
-                continue;
-            }
+            if (!isSpecialSection) continue;
 
-            if (line.contains("본 계약에 대하여")) {
+            if (endPattern.matcher(trimmedLine).find()) {
                 break;
             }
 
-            Matcher matcher = Pattern.compile(
-                    "^\\d+\\.\\s*(.+)"
-            ).matcher(line);
+            Matcher bulletMatcher = Pattern.compile("^(?:\\d+\\.|-|\\*|①|②|③|④|⑤)\\s*(.+)").matcher(trimmedLine);
 
-            if (matcher.find()) {
-
-                result.add(
-                        matcher.group(1).trim()
-                );
+            if (bulletMatcher.find()) {
+                result.add(bulletMatcher.group(1).trim());
+            } else {
+                if (trimmedLine.length() >= 5) {
+                    result.add(trimmedLine);
+                }
             }
         }
 
         return result;
     }
 
-    // =====================================================
-    // 당사자 추출
-    // =====================================================
-
-    private List<PartyResponse> extractParties(String[] lines) {
-
-        StringBuilder builder = new StringBuilder();
-
-        for (String line : lines) {
-
-            builder.append(line).append(" ");
-        }
-
-        String fullText = builder.toString();
-
-        String landlordName = null;
-        String landlordPhone = null;
-        String landlordAddress = null;
-
-        String tenantName = null;
-        String tenantPhone = null;
-        String tenantAddress = null;
-
-        // 임대인 이름
-        Matcher landlordMatcher = Pattern.compile(
-                "임대인.*?성\\s*명\\s*([가-힣]+)"
-        ).matcher(fullText);
-
-        if (landlordMatcher.find()) {
-
-            landlordName = landlordMatcher.group(1);
-        }
-
-        // 임대인 전화번호
-        Matcher landlordPhoneMatcher = Pattern.compile(
-                "임대인.*?(01[0-9]-\\d{3,4}-\\d{4})"
-        ).matcher(fullText);
-
-        if (landlordPhoneMatcher.find()) {
-
-            landlordPhone = landlordPhoneMatcher.group(1);
-        }
-
-        // 임차인 이름
-        Matcher tenantMatcher = Pattern.compile(
-                "임차인.*?성\\s*명\\s*([가-힣]+)"
-        ).matcher(fullText);
-
-        if (tenantMatcher.find()) {
-
-            tenantName = tenantMatcher.group(1);
-        }
-
-        // 임차인 전화번호
-        Matcher tenantPhoneMatcher = Pattern.compile(
-                "임차인.*?(01[0-9]-\\d{3,4}-\\d{4})"
-        ).matcher(fullText);
-
-        if (tenantPhoneMatcher.find()) {
-
-            tenantPhone = tenantPhoneMatcher.group(1);
-        }
-
-        return List.of(
-                new PartyResponse(
-                        landlordName,
-                        landlordPhone,
-                        landlordAddress,
-                        null,
-                        tenantName,
-                        tenantPhone,
-                        tenantAddress,
-                        null
-                )
-        );
-    }
-
-    // =====================================================
-    // 중개사 추출
-    // =====================================================
-
-    private List<AgentResponse> extractAgents(String[] lines) {
-
-        List<AgentResponse> result = new ArrayList<>();
-
-        StringBuilder builder = new StringBuilder();
-
-        for (String line : lines) {
-
-            builder.append(line).append(" ");
-        }
-
-        String text = builder.toString();
-
-        Pattern pattern = Pattern.compile(
-                "사무소명칭\\s*([가-힣A-Za-z0-9]+).*?" +
-                        "사무소소재지\\s*([가-힣0-9\\-\\s()]+).*?" +
-                        "(\\d{5}-\\d{4}-\\d{5}|가-\\d+-\\d+-\\d+)",
-                Pattern.DOTALL
-        );
-
-        Matcher matcher = pattern.matcher(text);
-
-        while (matcher.find()) {
-
-            result.add(
-                    new AgentResponse(
-                            matcher.group(1).trim(),
-                            matcher.group(2).trim(),
-                            null,
-                            matcher.group(3).trim()
-                    )
-            );
-        }
-
-        return result;
-    }
-
-    // =====================================================
-    // 계약일 추출
-    // =====================================================
-
-    private String extractContractDate(String text) {
-
-        Matcher matcher = Pattern.compile(
-                "\\d{4}년\\s*\\d{2}월\\s*\\d{2}일"
-        ).matcher(text);
-
-        return matcher.find()
-                ? matcher.group()
-                : null;
-    }
-
-    // =====================================================
-    // 조항번호 정리
-    // =====================================================
-
-    private String normalizeClauseNo(String clauseNo) {
-
-        Matcher matcher = Pattern.compile(
-                "제\\d+조|\\d+\\."
-        ).matcher(clauseNo);
-
+    // 조항번호 정규화
+    private String normalizeClauseNo(String title) {
+        Matcher matcher = Pattern.compile("제\\d+조|\\d+\\.").matcher(title);
         if (matcher.find()) {
-
             return matcher.group();
         }
-
-        return clauseNo.length() > 20
-                ? clauseNo.substring(0, 20)
-                : clauseNo;
-    }
-
-    // =====================================================
-    // 금액 파싱
-    // =====================================================
-
-    private Long parseMoney(String value) {
-
-        if (value == null) {
-            return null;
-        }
-
-        String onlyNumber = value.replaceAll("[^0-9]", "");
-
-        if (onlyNumber.isBlank()) {
-            return null;
-        }
-
-        return Long.parseLong(onlyNumber);
-    }
-
-    // =====================================================
-    // 면적 파싱
-    // =====================================================
-
-    private BigDecimal parseArea(String value) {
-
-        if (value == null) {
-            return null;
-        }
-
-        String onlyNumber = value.replaceAll("[^0-9.]", "");
-
-        if (onlyNumber.isBlank()) {
-            return null;
-        }
-
-        return new BigDecimal(onlyNumber);
-    }
-
-    // =====================================================
-    // 중개보수
-    // =====================================================
-
-    private Long extractBrokerFee(String text) {
-
-        Matcher matcher = Pattern.compile(
-                "중개보수\\s*([\\d,]+)"
-        ).matcher(text);
-
-        if (matcher.find()) {
-
-            return parseMoney(matcher.group(1));
-        }
-
-        return null;
+        return title.length() > 20 ? title.substring(0, 20) : title;
     }
 }


### PR DESCRIPTION
## 🧾 PR 제목
[Refactor/#11]문장 분리 및 조항 분리 구조 개선

---

## 📌 관련 이슈
- Closes #11

---

## ✨ PR 유형
- [ ] 신규 기능
- [ ] 버그 수정
- [X] 리팩토링
- [X] 문서 수정
- [ ] 기타 (설명 필요)

---

## 📋 작업 내용
- OCR 결과 파싱 시, 다양한 형태의 계약서(특이한 띄어쓰기, 오타, 괄호 모양)에서도 조항을 정확하게 분리할 수 있도록 정규식 고도화
- 이전에 제거되었던 표제부(Header) 추출 및 `ContractHeaderInfo` 테이블 저장 로직 복구
- 파싱 중 불필요한 노이즈 문자를 제거하는 전처리 메서드(`preprocess`) 복구

---

## 🔍 변경 사항
- `ContractParsingService.java`의 `extractClauses()` 내 정규식 변경: `([제체]\\s*\\d+\\s*조)[).]?\\s*[(\\[【<]([^)\\]】>]+)[)\\]】>]\\s*(.*?)(?=[제체]\\s*\\d+\\s*조|특\\s*약|본\\s*계약|$)`
- `ContractParsingService.java`의 `extractSpecialTerms()` 내 정규식 변경: 오탐지를 막기 위해 종료 조건을 `본 계약에`, `위와 같이` 등으로 강화
- `HeaderResponse` DTO를 반환하도록 DTO 및 파싱 반환부(`ParsingResponse`) 수정
- `ContractHeaderInfo` 엔티티를 생성하고 `headerRepository`를 통해 DB에 저장하는 로직 추가
---

## 🧪 테스트
- [X] 로컬 실행 확인
- [X] DB 연결 확인
- [X] API 정상 동작 확인 (Swagger 등)
- [ ] 기타 테스트:

---

## ⚠️ 주의 사항 (중요)
- 환경변수 변경 여부
- DB 구조 변경 여부
- 팀원에게 영향 있는 부분

---

## 📸 스크린샷 (선택)
- UI 변경 시 첨부

---

## 🔗 참고 자료
- 관련 문서 / 링크

---

## 📌 리뷰 요구 사항
- 집중적으로 봐야 할 부분
- 고민했던 부분

---

## 📌 PR 규칙
- 최소 1명 이상 승인 후 merge
- main 직접 push 금지
- dev 또는 feature 브랜치 사용