### PR TITLE
Feat/#23 logout withdraw

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -45,6 +45,7 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	annotationProcessor 'org.projectlombok:lombok'
+	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-data-redis-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-security-test'

--- a/backend/src/main/java/com/safesign/backend/BackendApplication.java
+++ b/backend/src/main/java/com/safesign/backend/BackendApplication.java
@@ -2,8 +2,11 @@ package com.safesign.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import com.safesign.backend.global.config.CookieProperties;
 
 @SpringBootApplication
+@EnableConfigurationProperties(CookieProperties.class)
 public class BackendApplication {
 
 	public static void main(String[] args) {

--- a/backend/src/main/java/com/safesign/backend/domain/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/safesign/backend/domain/auth/controller/AuthController.java
@@ -3,11 +3,20 @@ package com.safesign.backend.domain.auth.controller;
 import com.safesign.backend.domain.auth.dto.response.TokenResponse;
 import com.safesign.backend.domain.auth.dto.response.UserInfoResponse;
 import com.safesign.backend.domain.auth.service.RefreshTokenService;
+
 import com.safesign.backend.global.auth.CustomUserDetails;
 import com.safesign.backend.global.auth.jwt.JwtTokenProvider;
+import com.safesign.backend.global.config.CookieProperties;
+
 import jakarta.servlet.http.Cookie;
+import org.springframework.http.ResponseCookie;
+
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -20,6 +29,7 @@ public class AuthController {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenService refreshTokenService;
+    private final CookieProperties cookieProperties;
 
     @GetMapping("/me")
     public ResponseEntity<UserInfoResponse> me(
@@ -58,6 +68,21 @@ public class AuthController {
         return ResponseEntity.ok(new TokenResponse(newAccessToken));
     }
 
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            HttpServletResponse response
+    ) {
+        if (userDetails == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        refreshTokenService.deleteRefreshToken(userDetails.getUserId());
+        deleteRefreshTokenCookie(response);
+
+        return ResponseEntity.noContent().build();
+    }
+
     private String extractRefreshToken(HttpServletRequest request) {
         Cookie[] cookies = request.getCookies();
 
@@ -72,5 +97,17 @@ public class AuthController {
         }
 
         return null;
+    }
+
+    private void deleteRefreshTokenCookie(HttpServletResponse response) {
+        ResponseCookie cookie = ResponseCookie.from("refreshToken", "")
+                .httpOnly(true)
+                .secure(cookieProperties.isSecure())
+                .path("/")
+                .maxAge(0)
+                .sameSite(cookieProperties.getSameSite())
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
     }
 }

--- a/backend/src/main/java/com/safesign/backend/domain/auth/oauth/OAuth2SuccessHandler.java
+++ b/backend/src/main/java/com/safesign/backend/domain/auth/oauth/OAuth2SuccessHandler.java
@@ -2,11 +2,16 @@ package com.safesign.backend.domain.auth.oauth;
 
 import com.safesign.backend.domain.auth.service.RefreshTokenService;
 import com.safesign.backend.global.auth.jwt.JwtTokenProvider;
-import jakarta.servlet.ServletException;
+import com.safesign.backend.global.config.CookieProperties;
+
 import org.springframework.http.ResponseCookie;
+
+import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
@@ -21,6 +26,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenService refreshTokenService;
+    private final CookieProperties cookieProperties;
 
     @Value("${app.frontend-url}")
     private String frontendUrl;
@@ -52,14 +58,15 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
         ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", refreshToken)
                 .httpOnly(true)
-                .secure(false) // 로컬 false, 배포 HTTPS true
+                .secure(cookieProperties.isSecure())
                 .path("/")
-                .sameSite("Lax") // 로컬은 Lax 권장, 배포 시 None
+                .sameSite(cookieProperties.getSameSite())
                 .maxAge(jwtTokenProvider.getRefreshTokenExpiration() / 1000)
                 .build();
 
         response.addHeader("Set-Cookie", refreshTokenCookie.toString());
 
-        response.sendRedirect(frontendUrl + "/oauth/success");
+        response.sendRedirect("http://localhost:8080/swagger-ui/index.html");
+        //response.sendRedirect(frontendUrl + "/oauth/success");
     }
 }

--- a/backend/src/main/java/com/safesign/backend/domain/user/controller/UserController.java
+++ b/backend/src/main/java/com/safesign/backend/domain/user/controller/UserController.java
@@ -1,0 +1,26 @@
+package com.safesign.backend.domain.user.controller;
+
+import com.safesign.backend.domain.user.service.UserService;
+import com.safesign.backend.global.auth.CustomUserDetails;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @DeleteMapping("/me")
+    public ResponseEntity<Void> deleteMe(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            HttpServletResponse response
+    ) {
+        userService.deleteMe(userDetails.getUserId(), response);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/com/safesign/backend/domain/user/entity/User.java
+++ b/backend/src/main/java/com/safesign/backend/domain/user/entity/User.java
@@ -105,4 +105,14 @@ public class User {
     public void softDelete() {
         this.deletedAt = LocalDateTime.now();
     }
+
+    public void withdraw() {
+        String suffix = "_deleted_" + this.userId + "_" + System.currentTimeMillis();
+
+        this.email = "deleted_" + this.userId + "_" + System.currentTimeMillis() + "@deleted.local";
+        this.password = null;
+        this.name = "탈퇴한 사용자";
+        this.providerUserId = this.providerUserId + suffix;
+        this.deletedAt = LocalDateTime.now();
+    }
 }

--- a/backend/src/main/java/com/safesign/backend/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/safesign/backend/domain/user/service/UserService.java
@@ -1,0 +1,62 @@
+package com.safesign.backend.domain.user.service;
+
+import com.safesign.backend.domain.auth.service.RefreshTokenService;
+import com.safesign.backend.domain.user.entity.User;
+import com.safesign.backend.domain.user.repository.UserRepository;
+import com.safesign.backend.global.config.CookieProperties;
+import com.safesign.backend.global.exception.CustomException;
+import com.safesign.backend.global.exception.ErrorCode;
+
+import jakarta.servlet.http.HttpServletResponse;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final RefreshTokenService refreshTokenService;
+    private final CookieProperties cookieProperties;
+
+    public void deleteMe(
+            Long userId,
+            HttpServletResponse response
+    ) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() ->
+                        new CustomException(ErrorCode.USER_NOT_FOUND)
+                );
+
+        user.withdraw();
+
+        refreshTokenService.deleteRefreshToken(userId);
+        deleteRefreshTokenCookie(response);
+    }
+
+    private void deleteRefreshTokenCookie(
+            HttpServletResponse response
+    ) {
+        ResponseCookie cookie = ResponseCookie.from(
+                        "refreshToken",
+                        ""
+                )
+                .httpOnly(true)
+                .secure(cookieProperties.isSecure())
+                .path("/")
+                .maxAge(0)
+                .sameSite(cookieProperties.getSameSite())
+                .build();
+
+        response.addHeader(
+                HttpHeaders.SET_COOKIE,
+                cookie.toString()
+        );
+    }
+}

--- a/backend/src/main/java/com/safesign/backend/global/config/CookieProperties.java
+++ b/backend/src/main/java/com/safesign/backend/global/config/CookieProperties.java
@@ -1,0 +1,14 @@
+package com.safesign.backend.global.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "app.cookie")
+public class CookieProperties {
+
+    private boolean secure;
+    private String sameSite;
+}

--- a/backend/src/main/java/com/safesign/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/safesign/backend/global/config/SecurityConfig.java
@@ -37,21 +37,16 @@ public class SecurityConfig {
 
         http
                 .cors(Customizer.withDefaults())
-
                 .csrf(csrf -> csrf.disable())
-
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(
                                 SessionCreationPolicy.STATELESS
                         )
                 )
-
                 .formLogin(form -> form.disable())
-
                 .httpBasic(httpBasic -> httpBasic.disable())
-
+                .logout(logout -> logout.disable())
                 .authorizeHttpRequests(auth -> auth
-
                         // permitAll
                         .requestMatchers(
                                 "/swagger-ui/**",
@@ -67,6 +62,9 @@ public class SecurityConfig {
 
                                 "/api/v1/admin/auth/**"
                         ).permitAll()
+
+                        .requestMatchers("/api/v1/users/**")
+                        .authenticated()
 
                         // 관리자 전용
                         .requestMatchers("/api/v1/admin/**")


### PR DESCRIPTION
## 🧾 PR 제목
[Feat/#23] 로그아웃, 회원 탈퇴 기능


---

## 📌 관련 이슈
- Closes #23

---

## ✨ PR 유형
- [0] 신규 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명 필요)

---

## 📋 작업 내용
- 로그아웃 API 구현
   - Redis refresh token 삭제 처리
   - refreshToken 쿠키 삭제 처리
- 회원 탈퇴 API 구현
   - 회원 탈퇴 시 개인정보 익명화 처리
   - 탈퇴 후 동일 소셜 계정 재가입 가능하도록 처리(데이터는 초기화된 상태임)

---

## 🧪 테스트
- [0] 로컬 실행 확인
- [0] DB 연결 확인
- [0] API 정상 동작 확인 (Swagger 등)
   - 로그아웃 후 reissue 401 확인
   - Redis refresh token 삭제 확인
   - 회원 탈퇴 후 DB 익명화 확인
   - 동일 카카오 계정 재가입 시 새 user row 생성 확인

---

## ⚠️ 주의 사항 (중요)
- 환경변수 변경 여부(X)
- DB 구조 변경 여부(X)
- 팀원에게 영향 있는 부분(X) : AdminUserDeleteResponse 부분은 softdelete로 남겨놨음

---

## 📸 스크린샷 (선택)
로그아웃(Set_Cookie: refreshToken= ...Max-Age=0 보임)
<img width="1919" height="995" alt="image" src="https://github.com/user-attachments/assets/00d0f139-6e4a-4195-96a1-805ca309645b" />
탈퇴
<img width="1243" height="46" alt="image" src="https://github.com/user-attachments/assets/25d17849-1e8f-4ede-b6d2-4eb8f8f6c6a5" />

---

## 🔗 참고 자료
- 관련 문서 / 링크

---

## 📌 리뷰 요구 사항
- 집중적으로 봐야 할 부분
- 고민했던 부분

---

## 📌 PR 규칙
- 최소 1명 이상 승인 후 merge
- main 직접 push 금지
- dev 또는 feature 브랜치 사용