### PR TITLE
refactor : 문장 분리 및 조항 분리 구조 개선

### DIFF
--- a/backend/src/main/java/com/safesign/backend/domain/contract/service/ContractParsingService.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/service/ContractParsingService.java
@@ -147,28 +147,46 @@ public class ContractParsingService {
     }
 
     // 조항 추출 (제N조 및 특약사항)
-
     private List<ClauseResponse> extractClauses(String text) {
         List<ClauseResponse> clauses = new ArrayList<>();
         int orderNo = 1;
+        int lastMatchEndIndex = 0; // [수정] 마지막 제N조가 끝난 인덱스를 저장할 변수
 
         Pattern clausePattern = Pattern.compile(
-                "([제체]\\s*\\d+\\s*조)[).]?\\s*[(\\[【<]([^)\\]】>]+)[)\\]】>]\\s*(.*?)(?=[제체]\\s*\\d+\\s*조|특\\s*약|본\\s*계약|$)",
+                "([제체체]\\s*\\d+\\s*조)\\s*(?:[(\\[【<]([^)\\]】>]+)[)\\]】>])?\\s*(.*?)(?=[제체체]\\s*\\d+\\s*조|특\\s*약\\s*사\\s*항|특\\s*약|\\[\\s*특\\s*약\\s*\\]|$)",
                 Pattern.DOTALL
         );
         Matcher matcher = clausePattern.matcher(text);
 
         while (matcher.find()) {
             String clauseNo = matcher.group(1).replaceAll("\\s+", "").replace("체", "제");
-            String title = matcher.group(2).replaceAll("\\s+", " ").trim();
-            String content = matcher.group(3).replaceAll("\\s+", " ").trim();
+            String rawTitle = matcher.group(2);
+            String rawContent = matcher.group(3);
 
-            if (content.length() >= 5) {
-                clauses.add(new ClauseResponse(clauseNo + " [" + title + "]", content, orderNo++));
+            // 공백 정제
+            String content = rawContent != null ? rawContent.replaceAll("\\s+", " ").trim() : "";
+            String title;
+
+            if (rawTitle != null && !rawTitle.isBlank()) {
+                // 괄호 제목이 있는 경우 (예: 제1조 [목적])
+                title = clauseNo + " [" + rawTitle.replaceAll("\\s+", " ").trim() + "]";
+            } else {
+                title = clauseNo;
             }
+
+            if (content.length() >= 2) {
+                clauses.add(new ClauseResponse(title, content, orderNo++));
+            }
+
+            // [수정] 매칭이 성공할 때마다 끝나는 지점의 인덱스를 계속 업데이트
+            lastMatchEndIndex = matcher.end();
         }
 
-        List<String> specialTerms = extractSpecialTerms(text);
+        // [수정] 마지막 조항이 끝난 지점부터 계약서 끝까지의 잔여 텍스트를 추출
+        String potentialSpecialText = text.substring(lastMatchEndIndex);
+
+        // [수정] 추출한 잔여 텍스트를 특약사항 분석 메서드로 전달
+        List<String> specialTerms = extractSpecialTerms(potentialSpecialText);
         for (String special : specialTerms) {
             clauses.add(new ClauseResponse("특약사항", special, orderNo++));
         }
@@ -176,36 +194,39 @@ public class ContractParsingService {
         return clauses;
     }
 
-    // 특약사항 세부 문장 추출
-    private List<String> extractSpecialTerms(String text) {
+    // [수정] 특약사항 세부 문장 추출 (마지막 조항 이후의 잔여 텍스트를 받아 처리)
+    private List<String> extractSpecialTerms(String remainingText) {
         List<String> result = new ArrayList<>();
-        String[] lines = text.split("\n");
-        boolean isSpecialSection = false;
+        String[] lines = remainingText.split("\n");
 
-        Pattern startPattern = Pattern.compile("특\\s*약\\s*사\\s*항|특\\s*약\\s*조\\s*건|특\\s*수\\s*조\\s*건|특\\s*약|\\[\\s*특\\s*약\\s*]");
+        // 하단 서명부나 날짜 영역을 만나면 수집을 중단하기 위한 패턴
         Pattern endPattern = Pattern.compile("^\\s*(본\\s*계약에|위와\\s*같이|계약을\\s*체결|\\d{4}년\\s*\\d{1,2}월|임\\s*대\\s*인\\s*$|매\\s*도\\s*인\\s*$|임\\s*차\\s*인\\s*$)");
 
         for (String line : lines) {
             String trimmedLine = line.trim();
             if (trimmedLine.isEmpty()) continue;
 
-            if (!isSpecialSection && startPattern.matcher(trimmedLine).find()) {
-                isSpecialSection = true;
-                continue;
-            }
-
-            if (!isSpecialSection) continue;
-
+            // 서명부나 날짜를 만나면 특약사항 수집 즉시 종료
             if (endPattern.matcher(trimmedLine).find()) {
                 break;
             }
 
-            Matcher bulletMatcher = Pattern.compile("^(?:\\d+\\.|-|\\*|①|②|③|④|⑤)\\s*(.+)").matcher(trimmedLine);
+            // 만약 '[특약사항]' 같은 타이틀 줄이 텍스트에 포함되어 있다면, 데이터로 저장하지 않고 패스
+            if (trimmedLine.matches(".*(특\\s*약\\s*사\\s*항|특\\s*약\\s*조\\s*건|특\\s*특\\s*약).*")) {
+                continue;
+            }
+
+            // 1., 2., *, ①, 2-1. 등의 불릿 기호 처리 정규식
+            Matcher bulletMatcher = Pattern.compile("^(?:\\d+\\.|-|\\*|①|②|③|④|⑤|\\d+-\\d+\\.)\\s*(.+)").matcher(trimmedLine);
 
             if (bulletMatcher.find()) {
-                result.add(bulletMatcher.group(1).trim());
+                String content = bulletMatcher.group(1).trim();
+                if (content.length() >= 2) {
+                    result.add(content);
+                }
             } else {
-                if (trimmedLine.length() >= 5) {
+                // 불릿 번호가 없더라도 의미 있는 문장이면 특약사항으로 인정 (노이즈 방지를 위해 최소 4자 이상)
+                if (trimmedLine.length() >= 4) {
                     result.add(trimmedLine);
                 }
             }


### PR DESCRIPTION
## 🧾 PR 제목
[Refactor/#11] 문장 분리 및 조항 분리 구조 개선

---

## 📌 관련 이슈
- Closes #11

---

## ✨ PR 유형
- [ ] 신규 기능
- [ ] 버그 수정
- [X] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명 필요)

---

## 📋 작업 내용
- **조항 추출 정규식 완화 (`extractClauses`)**
  - 조항 제목(괄호 `[...]`)이 없는 계약서 양식도 정상 인식하도록 수정
  - 제목이 없는 조항은 타이틀을 깔끔하게 조항 번호(예: `제1조`)만 들어가도록 가공
  - 본문 단어인 `본 계약` 때문에 중간에 텍스트가 끊기던 전방탐색 버그 해결
- **특약사항 추출 프로세스 개선 (`extractSpecialTerms`)**
  - `[특약사항]` 타이틀이 없는 계약서에 대응하기 위해, **마지막 조항이 끝난 위치(`lastMatchEndIndex`) 이후의 남은 텍스트**를 전부 특약사항으로 인식하도록 구조 변경
  - 하단 서명부/날짜 인식 시 수집을 종료하는 방어 로직 강화
- **표제부 줄바꿈 대응 (`extractHeaderInfo`)**
  - 키워드(예: 소재지, 보증금) 바로 다음 줄에 데이터가 있는 경우, 아래 줄(`index + 1`)까지 탐색하여 유실 없이 바인딩
---

## 🔍 변경 사항
- 핵심 변경 로직
- 추가/수정된 파일
- DB / API / 설정 변경 여부

---

## 🧪 테스트
- [x] 로컬 실행 확인
- [x] DB 연결 확인
- [x] API 정상 동작 확인 (Swagger 등)
- [ ] 기타 테스트:

---

## ⚠️ 주의 사항 (중요)
- 환경변수 변경 여부
- DB 구조 변경 여부
- 팀원에게 영향 있는 부분

---

## 📸 스크린샷 (선택)
<img width="2690" height="1002" alt="image" src="https://github.com/user-attachments/assets/6c1feec5-b465-4036-beb3-058d4aadcc1b" />
---

## 🔗 참고 자료
- 관련 문서 / 링크

---

## 📌 리뷰 요구 사항
- 집중적으로 봐야 할 부분
- 고민했던 부분

---

## 📌 PR 규칙
- 최소 1명 이상 승인 후 merge
- main 직접 push 금지
- dev 또는 feature 브랜치 사용