### PR TITLE
feat: add local and s3 file storage strategy

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -40,6 +40,7 @@ dependencies {
 	implementation 'org.apache.pdfbox:pdfbox:3.0.3'
 	implementation 'com.azure:azure-ai-documentintelligence:1.0.7'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'software.amazon.awssdk:s3:2.25.60'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.postgresql:postgresql'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/backend/src/main/java/com/safesign/backend/domain/contract/service/FileStorageService.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/service/FileStorageService.java
@@ -1,64 +1,11 @@
 package com.safesign.backend.domain.contract.service;
 
 import com.safesign.backend.domain.contract.dto.response.StoredFileInfo;
-import com.safesign.backend.global.exception.CustomException;
-import com.safesign.backend.global.exception.ErrorCode;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.UUID;
+public interface FileStorageService {
 
-@Service
-public class FileStorageService {
+    StoredFileInfo storeFile(MultipartFile file, Long contractId);
 
-    @Value("${file.upload-dir}")
-    private String uploadDir;
-
-    public StoredFileInfo storeFile(MultipartFile file, Long contractId) {
-        validateFileExists(file);
-
-        try {
-            String originalFileName = file.getOriginalFilename();
-            String storedFileName = generateStoredFileName(originalFileName);
-
-            Path contractDir = Paths.get(uploadDir, String.valueOf(contractId));
-            Files.createDirectories(contractDir);
-
-            Path targetPath = contractDir.resolve(storedFileName);
-            file.transferTo(targetPath.toFile());
-
-            return StoredFileInfo.builder()
-                    .originalFileName(originalFileName)
-                    .storedFileName(storedFileName)
-                    .fileUrl(targetPath.toString())
-                    .mimeType(file.getContentType())
-                    .fileSize(file.getSize())
-                    .build();
-
-        } catch (IOException e) {
-            throw new CustomException(ErrorCode.FILE_STORAGE_FAILED);
-        }
-    }
-
-    private void validateFileExists(MultipartFile file) {
-        if (file == null || file.isEmpty()) {
-            throw new CustomException(ErrorCode.EMPTY_UPLOAD_FILE);
-        }
-    }
-
-    private String generateStoredFileName(String originalFileName) {
-        String uuid = UUID.randomUUID().toString();
-
-        if (originalFileName == null || !originalFileName.contains(".")) {
-            return uuid;
-        }
-
-        String extension = originalFileName.substring(originalFileName.lastIndexOf("."));
-        return uuid + extension;
-    }
+    byte[] loadFile(String fileUrl);
 }

--- a/backend/src/main/java/com/safesign/backend/domain/contract/service/LocalFileStorageService.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/service/LocalFileStorageService.java
@@ -1,0 +1,78 @@
+package com.safesign.backend.domain.contract.service;
+
+import com.safesign.backend.domain.contract.dto.response.StoredFileInfo;
+import com.safesign.backend.global.exception.CustomException;
+import com.safesign.backend.global.exception.ErrorCode;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
+
+@Service
+@Primary
+@Profile("local")
+public class LocalFileStorageService implements FileStorageService {
+
+    @Value("${file.upload-dir}")
+    private String uploadDir;
+
+    @Override
+    public StoredFileInfo storeFile(MultipartFile file, Long contractId) {
+        validateFileExists(file);
+
+        try {
+            String originalFileName = file.getOriginalFilename();
+            String storedFileName = generateStoredFileName(originalFileName);
+
+            Path contractDir = Paths.get(uploadDir, String.valueOf(contractId));
+            Files.createDirectories(contractDir);
+
+            Path targetPath = contractDir.resolve(storedFileName);
+            file.transferTo(targetPath.toFile());
+
+            return StoredFileInfo.builder()
+                    .originalFileName(originalFileName)
+                    .storedFileName(storedFileName)
+                    .fileUrl(targetPath.toString())
+                    .mimeType(file.getContentType())
+                    .fileSize(file.getSize())
+                    .build();
+
+        } catch (IOException e) {
+            throw new CustomException(ErrorCode.FILE_STORAGE_FAILED);
+        }
+    }
+
+    @Override
+    public byte[] loadFile(String fileUrl) {
+        try {
+            return Files.readAllBytes(Path.of(fileUrl));
+        } catch (IOException e) {
+            throw new CustomException(ErrorCode.FILE_STORAGE_FAILED);
+        }
+    }
+
+    private void validateFileExists(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new CustomException(ErrorCode.EMPTY_UPLOAD_FILE);
+        }
+    }
+
+    private String generateStoredFileName(String originalFileName) {
+        String uuid = UUID.randomUUID().toString();
+
+        if (originalFileName == null || !originalFileName.contains(".")) {
+            return uuid;
+        }
+
+        String extension = originalFileName.substring(originalFileName.lastIndexOf("."));
+        return uuid + extension;
+    }
+}

--- a/backend/src/main/java/com/safesign/backend/domain/contract/service/S3FileStorageService.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/service/S3FileStorageService.java
@@ -1,0 +1,95 @@
+package com.safesign.backend.domain.contract.service;
+
+import com.safesign.backend.domain.contract.dto.response.StoredFileInfo;
+import com.safesign.backend.global.exception.CustomException;
+import com.safesign.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Profile("s3")
+public class S3FileStorageService implements FileStorageService {
+
+    private final S3Client s3Client;
+
+    @Value("${aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${aws.s3.base-prefix}")
+    private String basePrefix;
+
+    @Override
+    public StoredFileInfo storeFile(MultipartFile file, Long contractId) {
+
+        try {
+            String originalFileName = file.getOriginalFilename();
+            String storedFileName = generateStoredFileName(originalFileName);
+
+            String objectKey =
+                    basePrefix + "/" + contractId + "/" + storedFileName;
+
+            PutObjectRequest request = PutObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(objectKey)
+                    .contentType(file.getContentType())
+                    .build();
+
+            s3Client.putObject(
+                    request,
+                    RequestBody.fromBytes(file.getBytes())
+            );
+
+            return StoredFileInfo.builder()
+                    .originalFileName(originalFileName)
+                    .storedFileName(storedFileName)
+                    .fileUrl(objectKey)
+                    .mimeType(file.getContentType())
+                    .fileSize(file.getSize())
+                    .build();
+
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.FILE_STORAGE_FAILED);
+        }
+    }
+
+    @Override
+    public byte[] loadFile(String fileUrl) {
+
+        try {
+            GetObjectRequest request = GetObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(fileUrl)
+                    .build();
+
+            ResponseBytes<?> response =
+                    s3Client.getObjectAsBytes(request);
+
+            return response.asByteArray();
+
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.FILE_STORAGE_FAILED);
+        }
+    }
+
+    private String generateStoredFileName(String originalFileName) {
+        String uuid = UUID.randomUUID().toString();
+
+        if (originalFileName == null || !originalFileName.contains(".")) {
+            return uuid;
+        }
+
+        String extension = originalFileName.substring(originalFileName.lastIndexOf("."));
+        return uuid + extension;
+    }
+}

--- a/backend/src/main/java/com/safesign/backend/domain/ocr/service/OcrService.java
+++ b/backend/src/main/java/com/safesign/backend/domain/ocr/service/OcrService.java
@@ -9,6 +9,7 @@ import com.safesign.backend.domain.contract.entity.Contract;
 import com.safesign.backend.domain.contract.entity.ContractFile;
 import com.safesign.backend.domain.contract.enums.ContractStatus;
 import com.safesign.backend.domain.contract.repository.ContractRepository;
+import com.safesign.backend.domain.contract.service.FileStorageService;
 import com.safesign.backend.domain.ocr.client.AzureOcrClient;
 import com.safesign.backend.domain.ocr.config.AzureOcrProperties;
 import com.safesign.backend.domain.ocr.entity.OcrLine;
@@ -25,8 +26,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -44,6 +43,7 @@ public class OcrService {
     private final AzureOcrClient azureOcrClient;
     private final AzureOcrProperties azureOcrProperties;
     private final ObjectMapper objectMapper;
+    private final FileStorageService fileStorageService;
 
     public void process(Long userId, Long contractId) {
         Contract contract = contractRepository
@@ -64,7 +64,8 @@ public class OcrService {
         ocrResultRepository.save(ocrResult);
 
         try {
-            byte[] fileBytes = Files.readAllBytes(Path.of(contractFile.getFileUrl()));
+            byte[] fileBytes =
+                    fileStorageService.loadFile(contractFile.getFileUrl());
             AnalyzeResult analyzeResult =
                     azureOcrClient.analyze(fileBytes, azureOcrProperties.modelId());
 

--- a/backend/src/main/java/com/safesign/backend/global/config/S3Config.java
+++ b/backend/src/main/java/com/safesign/backend/global/config/S3Config.java
@@ -1,0 +1,21 @@
+package com.safesign.backend.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+
+    @Value("${aws.s3.region}")
+    private String region;
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .build();
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -75,3 +75,9 @@ app:
   cookie:
     secure: ${COOKIE_SECURE}
     same-site: ${COOKIE_SAME_SITE}
+
+aws:
+  s3:
+    bucket: ${AWS_S3_BUCKET}
+    region: ${AWS_REGION}
+    base-prefix: ${AWS_S3_BASE_PREFIX}


### PR DESCRIPTION
## 🧾 PR 제목
[Feat/#30] Local/S3 파일 저장 전략 분리 및 S3 저장소 구조 추가
---

## 📌 관련 이슈
- Closes #30

---

## ✨ PR 유형
- [0] 신규 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명 필요)

---

## 📋 작업 내용
- Local / S3 파일 저장 전략 분리
- S3 기반 파일 업로드 및 다운로드 구조 추가
- OCR 서비스가 저장소 종류와 관계없이 파일을 읽을 수 있도록 구조 개선
- Spring Profile 기반 저장소 전략 적용
---

## 🔍 변경 사항
- `FileStorageService`를 인터페이스로 변경
- `LocalFileStorageService` 구현체 추가
- `S3FileStorageService` 구현체 추가
- `OcrService`에서 직접 파일 경로를 읽는 방식 제거
- `FileStorageService.loadFile()` 기반으로 변경
- AWS S3 설정 및 `S3Client` Bean 추가
- AWS SDK S3 의존성 추가
- Profile(local/s3) 기반 저장 전략 분리

---
### 추가/수정된 주요 파일
- `FileStorageService.java`
- `LocalFileStorageService.java`
- `S3FileStorageService.java`
- `S3Config.java`
- `OcrService.java`
- `build.gradle`
- `application.yml`

---
## 🧪 테스트
- [0] 로컬 실행 확인
- [0] DB 연결 확인
- [0] API 정상 동작 확인 (Swagger 등)
- [ ] 기타 테스트:

---

## ⚠️ 주의 사항 (중요)
- 환경변수 변경 여부
   - AWS S3 환경변수 추가
   - Spring Profile 사용 (`local`, `s3`)
- `.env` 환경변수 추가 필요(Notion 확인)
  - `AWS_REGION`
  - `AWS_S3_BUCKET`
  - `AWS_S3_BASE_PREFIX`
- 배포 환경에서는 EC2 IAM Role 기반 S3 접근 예정
- 로컬 테스트 시 `SPRING_PROFILES_ACTIVE` 값 확인 필요
---

## 📸 스크린샷 (선택)
- UI 변경 시 첨부

---

## 🔗 참고 자료
- 관련 문서 / 링크

---

## 📌 리뷰 요구 사항
- 집중적으로 봐야 할 부분
- 고민했던 부분

---

## 📌 PR 규칙
- 최소 1명 이상 승인 후 merge
- main 직접 push 금지
- dev 또는 feature 브랜치 사용