### PR TITLE
feat: 계약서 목록 조회 및 삭제 기능 구현

### DIFF
--- a/backend/src/main/java/com/safesign/backend/domain/contract/controller/ContractController.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/controller/ContractController.java
@@ -1,8 +1,10 @@
 package com.safesign.backend.domain.contract.controller;
 
 import com.safesign.backend.domain.contract.dto.response.ContractUploadResponse;
+import com.safesign.backend.domain.contract.dto.response.ContractListResponse;
 import com.safesign.backend.domain.contract.enums.UploadType;
 import com.safesign.backend.domain.contract.service.ContractService;
+import com.safesign.backend.domain.contract.service.ContractQueryService;
 import com.safesign.backend.global.auth.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -19,6 +21,7 @@ import java.util.List;
 public class ContractController {
 
     private final ContractService contractService;
+    private final ContractQueryService contractQueryService;
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @ResponseStatus(HttpStatus.CREATED)
@@ -31,5 +34,27 @@ public class ContractController {
         Long userId = userDetails.getUserId();
 
         return contractService.uploadContract(userId, files, title, uploadType);
+    }
+
+    @GetMapping
+    public ContractListResponse getContracts(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) String keyword,
+            @RequestParam(defaultValue = "latest") String sort
+    ) {
+        Long userId = userDetails.getUserId();
+
+        return contractQueryService.getContracts(userId, keyword, sort);
+    }
+
+    @DeleteMapping("/{contractId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteContract(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long contractId
+    ) {
+        Long userId = userDetails.getUserId();
+
+        contractService.deleteContract(userId, contractId);
     }
 }

--- a/backend/src/main/java/com/safesign/backend/domain/contract/dto/response/ContractListItemResponse.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/dto/response/ContractListItemResponse.java
@@ -1,0 +1,18 @@
+package com.safesign.backend.domain.contract.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ContractListItemResponse {
+
+    private Long contractId;
+    private String title;
+    private Integer riskScore;
+    private long riskCount;
+    private LocalDateTime analyzedAt;
+    private LocalDateTime uploadedAt;
+}

--- a/backend/src/main/java/com/safesign/backend/domain/contract/dto/response/ContractListResponse.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/dto/response/ContractListResponse.java
@@ -1,0 +1,14 @@
+package com.safesign.backend.domain.contract.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ContractListResponse {
+
+    private ContractSummaryResponse summary;
+    private List<ContractListItemResponse> contracts;
+}

--- a/backend/src/main/java/com/safesign/backend/domain/contract/dto/response/ContractSummaryResponse.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/dto/response/ContractSummaryResponse.java
@@ -1,0 +1,14 @@
+package com.safesign.backend.domain.contract.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ContractSummaryResponse {
+
+    private long total;
+    private long high;
+    private long medium;
+    private long low;
+}

--- a/backend/src/main/java/com/safesign/backend/domain/contract/entity/Contract.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/entity/Contract.java
@@ -4,6 +4,7 @@ import com.safesign.backend.domain.contract.enums.ContractStatus;
 import com.safesign.backend.domain.contract.enums.UploadSource;
 import com.safesign.backend.domain.contract.enums.UploadType;
 import com.safesign.backend.domain.user.entity.User;
+import com.safesign.backend.domain.ocr.entity.OcrResult;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -65,6 +66,18 @@ public class Contract {
     @OneToMany(mappedBy = "contract", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ContractFile> contractFiles = new ArrayList<>();
 
+    @OneToMany(mappedBy = "contract", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ContractClause> contractClauses = new ArrayList<>();
+
+    @OneToMany(mappedBy = "contract", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ContractHeaderInfo> contractHeaderInfos = new ArrayList<>();
+
+    @OneToMany(mappedBy = "contract", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<OcrResult> ocrResults = new ArrayList<>();
+
+    @OneToMany(mappedBy = "contract", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ContractAnalysisResult> analysisResults = new ArrayList<>();
+
     @Builder
     public Contract(
             User user,
@@ -89,6 +102,11 @@ public class Contract {
     public void addContractFile(ContractFile contractFile) {
         this.contractFiles.add(contractFile);
         contractFile.assignContract(this);
+    }
+
+    public void addContractClause(ContractClause contractClause) {
+        this.contractClauses.add(contractClause);
+        contractClause.setContract(this);
     }
 
     public void updatePageCount(Integer pageCount) {

--- a/backend/src/main/java/com/safesign/backend/domain/contract/entity/ContractAnalysisResult.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/entity/ContractAnalysisResult.java
@@ -21,6 +21,8 @@ public class ContractAnalysisResult {
     @JoinColumn(name = "contract_id", nullable = false)
     private Contract contract;
 
+
+
     @Column(nullable = false)
     private Integer overallRiskScore;
 

--- a/backend/src/main/java/com/safesign/backend/domain/contract/repository/ContractAnalysisResultRepository.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/repository/ContractAnalysisResultRepository.java
@@ -1,0 +1,14 @@
+package com.safesign.backend.domain.contract.repository;
+
+import com.safesign.backend.domain.contract.entity.ContractAnalysisResult;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ContractAnalysisResultRepository extends JpaRepository<ContractAnalysisResult, Long> {
+
+    Optional<ContractAnalysisResult> findTopByContract_ContractIdOrderByCreatedAtDesc(Long contractId);
+
+    List<ContractAnalysisResult> findByContract_User_UserId(Long userId);
+}

--- a/backend/src/main/java/com/safesign/backend/domain/contract/repository/ContractRepository.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/repository/ContractRepository.java
@@ -3,9 +3,24 @@ package com.safesign.backend.domain.contract.repository;
 import com.safesign.backend.domain.contract.entity.Contract;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ContractRepository extends JpaRepository<Contract, Long> {
 
     Optional<Contract> findByContractIdAndUser_UserId(Long contractId, Long userId);
+
+    List<Contract> findByUser_UserIdOrderByUploadedAtDesc(Long userId);
+
+    List<Contract> findByUser_UserIdAndTitleContainingIgnoreCaseOrderByUploadedAtDesc(
+            Long userId,
+            String keyword
+    );
+
+    List<Contract> findByUser_UserIdOrderByUploadedAtAsc(Long userId);
+
+    List<Contract> findByUser_UserIdAndTitleContainingIgnoreCaseOrderByUploadedAtAsc(
+            Long userId,
+            String keyword
+    );
 }

--- a/backend/src/main/java/com/safesign/backend/domain/contract/service/ContractQueryService.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/service/ContractQueryService.java
@@ -1,0 +1,122 @@
+package com.safesign.backend.domain.contract.service;
+
+import com.safesign.backend.domain.contract.dto.response.ContractListItemResponse;
+import com.safesign.backend.domain.contract.dto.response.ContractListResponse;
+import com.safesign.backend.domain.contract.dto.response.ContractSummaryResponse;
+import com.safesign.backend.domain.contract.entity.Contract;
+import com.safesign.backend.domain.contract.entity.ContractAnalysisResult;
+import com.safesign.backend.domain.contract.repository.ContractAnalysisResultRepository;
+import com.safesign.backend.domain.contract.repository.ContractRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ContractQueryService {
+
+    private final ContractRepository contractRepository;
+    private final ContractAnalysisResultRepository contractAnalysisResultRepository;
+
+    public ContractListResponse getContracts(Long userId, String keyword, String sort) {
+        List<Contract> contracts = getContractsBySort(userId, keyword, sort);
+
+        List<ContractListItemResponse> items = contracts.stream()
+                .map(this::toContractListItem)
+                .toList();
+
+        items = sortItems(items, sort);
+
+        return ContractListResponse.builder()
+                .summary(buildSummary(items))
+                .contracts(items)
+                .build();
+    }
+
+    private List<Contract> getContractsBySort(Long userId, String keyword, String sort) {
+        boolean blankKeyword = isBlank(keyword);
+
+        if ("oldest".equals(sort)) {
+            return blankKeyword
+                    ? contractRepository.findByUser_UserIdOrderByUploadedAtAsc(userId)
+                    : contractRepository.findByUser_UserIdAndTitleContainingIgnoreCaseOrderByUploadedAtAsc(userId, keyword);
+        }
+
+        return blankKeyword
+                ? contractRepository.findByUser_UserIdOrderByUploadedAtDesc(userId)
+                : contractRepository.findByUser_UserIdAndTitleContainingIgnoreCaseOrderByUploadedAtDesc(userId, keyword);
+    }
+
+    private List<ContractListItemResponse> sortItems(List<ContractListItemResponse> items, String sort) {
+        if ("riskDesc".equals(sort)) {
+            return items.stream()
+                    .sorted((a, b) -> Integer.compare(
+                            b.getRiskScore() == null ? -1 : b.getRiskScore(),
+                            a.getRiskScore() == null ? -1 : a.getRiskScore()
+                    ))
+                    .toList();
+        }
+
+        if ("riskAsc".equals(sort)) {
+            return items.stream()
+                    .sorted((a, b) -> Integer.compare(
+                            a.getRiskScore() == null ? 101 : a.getRiskScore(),
+                            b.getRiskScore() == null ? 101 : b.getRiskScore()
+                    ))
+                    .toList();
+        }
+
+        return items;
+    }
+
+    private ContractListItemResponse toContractListItem(Contract contract) {
+        ContractAnalysisResult analysisResult = contractAnalysisResultRepository
+                .findTopByContract_ContractIdOrderByCreatedAtDesc(contract.getContractId())
+                .orElse(null);
+
+        return ContractListItemResponse.builder()
+                .contractId(contract.getContractId())
+                .title(contract.getTitle())
+                .uploadedAt(contract.getUploadedAt())
+                .analyzedAt(analysisResult == null ? null : analysisResult.getCreatedAt())
+                .riskScore(analysisResult == null ? null : analysisResult.getOverallRiskScore())
+                .riskCount(analysisResult == null ? 0 : countRiskClauses(analysisResult))
+                .build();
+    }
+
+    private long countRiskClauses(ContractAnalysisResult analysisResult) {
+        return analysisResult.getClauseAnalyses().stream()
+                .filter(clause -> clause.getRiskScore() != null && clause.getRiskScore() >= 40)
+                .count();
+    }
+
+    private ContractSummaryResponse buildSummary(List<ContractListItemResponse> items) {
+        long high = items.stream()
+                .filter(item -> item.getRiskScore() != null && item.getRiskScore() >= 70)
+                .count();
+
+        long medium = items.stream()
+                .filter(item -> item.getRiskScore() != null
+                        && item.getRiskScore() >= 40
+                        && item.getRiskScore() < 70)
+                .count();
+
+        long low = items.stream()
+                .filter(item -> item.getRiskScore() != null && item.getRiskScore() < 40)
+                .count();
+
+        return ContractSummaryResponse.builder()
+                .total(items.size())
+                .high(high)
+                .medium(medium)
+                .low(low)
+                .build();
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.trim().isEmpty();
+    }
+}

--- a/backend/src/main/java/com/safesign/backend/domain/contract/service/ContractService.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/service/ContractService.java
@@ -45,6 +45,13 @@ public class ContractService {
         };
     }
 
+    public void deleteContract(Long userId, Long contractId) {
+        Contract contract = contractRepository.findByContractIdAndUser_UserId(contractId, userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.CONTRACT_NOT_FOUND));
+
+        contractRepository.delete(contract);
+    }
+    
     private ContractUploadResponse uploadPdf(List<MultipartFile> files, String title, User user) {
         if (files.size() != 1) {
             throw new CustomException(ErrorCode.INVALID_PDF_FILE_COUNT);

--- a/backend/src/main/java/com/safesign/backend/domain/contract/service/FileStorageService.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/service/FileStorageService.java
@@ -8,4 +8,6 @@ public interface FileStorageService {
     StoredFileInfo storeFile(MultipartFile file, Long contractId);
 
     byte[] loadFile(String fileUrl);
+
+    void deleteFile(String fileUrl);
 }

--- a/backend/src/main/java/com/safesign/backend/domain/contract/service/LocalFileStorageService.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/service/LocalFileStorageService.java
@@ -15,6 +15,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.UUID;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 @Service
 @Primary
 @Profile("local")
@@ -56,6 +59,15 @@ public class LocalFileStorageService implements FileStorageService {
             return Files.readAllBytes(Path.of(fileUrl));
         } catch (IOException e) {
             throw new CustomException(ErrorCode.FILE_STORAGE_FAILED);
+        }
+    }
+
+    @Override
+    public void deleteFile(String fileUrl) {
+        try {
+            Files.deleteIfExists(Paths.get(fileUrl));
+        } catch (IOException e) {
+            log.warn("로컬 파일 삭제 실패 - fileUrl={}", fileUrl, e);
         }
     }
 

--- a/backend/src/main/java/com/safesign/backend/domain/contract/service/S3FileStorageService.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/service/S3FileStorageService.java
@@ -13,9 +13,13 @@ import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 
 import java.util.UUID;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Profile("s3")
@@ -79,6 +83,18 @@ public class S3FileStorageService implements FileStorageService {
 
         } catch (Exception e) {
             throw new CustomException(ErrorCode.FILE_STORAGE_FAILED);
+        }
+    }
+
+    @Override
+    public void deleteFile(String fileUrl) {
+        try {
+            s3Client.deleteObject(DeleteObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(fileUrl)
+                    .build());
+        } catch (Exception e) {
+            log.warn("S3 파일 삭제 실패 - fileUrl={}", fileUrl, e);
         }
     }
 

--- a/backend/src/main/java/com/safesign/backend/domain/ocr/entity/OcrPage.java
+++ b/backend/src/main/java/com/safesign/backend/domain/ocr/entity/OcrPage.java
@@ -8,6 +8,8 @@ import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -22,6 +24,9 @@ public class OcrPage {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ocr_result_id", nullable = false)
     private OcrResult ocrResult;
+
+    @OneToMany(mappedBy = "ocrPage", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<OcrLine> lines = new ArrayList<>();
 
     @Column(nullable = false)
     private Integer pageNumber;

--- a/backend/src/main/java/com/safesign/backend/domain/ocr/entity/OcrResult.java
+++ b/backend/src/main/java/com/safesign/backend/domain/ocr/entity/OcrResult.java
@@ -9,6 +9,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -23,6 +25,9 @@ public class OcrResult {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "contract_id", nullable = false)
     private Contract contract;
+
+    @OneToMany(mappedBy = "ocrResult", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<OcrPage> pages = new ArrayList<>();
 
     @Column(nullable = false, length = 30)
     private String provider;

--- a/backend/src/main/java/com/safesign/backend/domain/ocr/service/OcrService.java
+++ b/backend/src/main/java/com/safesign/backend/domain/ocr/service/OcrService.java
@@ -90,7 +90,6 @@ public class OcrService {
         } catch (Exception e) {
             log.error("OCR 처리 실패 - contractId={}", contractId, e);
 
-
             ocrResult.fail(e.getMessage());
             contract.updateStatus(ContractStatus.OCR_FAILED);
             contract.updateFailureReason(e.getMessage());


### PR DESCRIPTION
## 🧾 PR 제목
[Feat/#38] 내 계약서 분석 목록 조회 및 삭제 기능 구현

---

## 📌 관련 이슈
- Closes #38

---

## ✨ PR 유형
- [0] 신규 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명 필요)

---

## 📋 작업 내용
- 계약서 목록 조회 API 구현
- 계약서 검색 기능 추가
- 계약서 정렬 기능 추가
  - 최신순
  - 과거순
  - 위험도순
- 계약서 전체, 위험, 주의, 안전 갯수 제공
- 계약서 삭제 API 구현
- 계약서 삭제 시 연관 데이터 cascade 삭제 처리
- Local/S3 파일 삭제 로직 구현

---

## 🔍추가/수정된 파일
- ContractController
- ContractService
- ContractQueryService
- ContractRepository
- ContractAnalysisResultRepository
- FileStorageService
- LocalFileStorageService
- S3FileStorageService
- Contract 엔티티
- OcrResult 엔티티
- OcrPage 엔티티

---

## 🧪 테스트
- [0] 로컬 실행 확인
- [0] DB 연결 확인
- [0] API 정상 동작 확인 (Swagger 등)
- [ ] 기타 테스트:

---

## ⚠️ 주의 사항 (중요)
- contract 삭제 시 연관 엔티티 cascade 삭제 적용
- OcrResult ↔ OcrPage ↔ OcrLine 연관관계 추가

---

## 📸 스크린샷 (선택)
- UI 변경 시 첨부

---

## 🔗 참고 자료
- 관련 문서 / 링크

---

## 📌 리뷰 요구 사항
- 집중적으로 봐야 할 부분
- 고민했던 부분

---

## 📌 PR 규칙
- 최소 1명 이상 승인 후 merge
- main 직접 push 금지
- dev 또는 feature 브랜치 사용