### PR TITLE
feat: add main dashboard

### DIFF
--- a/backend/src/main/java/com/safesign/backend/domain/contract/repository/ContractAnalysisResultRepository.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/repository/ContractAnalysisResultRepository.java
@@ -2,13 +2,49 @@ package com.safesign.backend.domain.contract.repository;
 
 import com.safesign.backend.domain.contract.entity.ContractAnalysisResult;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
+import java.time.LocalDateTime;
 
 public interface ContractAnalysisResultRepository extends JpaRepository<ContractAnalysisResult, Long> {
 
     Optional<ContractAnalysisResult> findTopByContract_ContractIdOrderByCreatedAtDesc(Long contractId);
 
     List<ContractAnalysisResult> findByContract_User_UserId(Long userId);
+
+    @Query("""
+        select count(ar)
+        from ContractAnalysisResult ar
+        where ar.contract.user.userId = :userId
+          and ar.overallRiskScore >= :riskScore
+    """)
+    Long countRiskyAnalysesByUserId(Long userId, Integer riskScore);
+
+    @Query("""
+        select count(ar)
+        from ContractAnalysisResult ar
+        where ar.contract.user.userId = :userId
+          and ar.createdAt >= :startOfMonth
+          and ar.createdAt < :startOfNextMonth
+    """)
+    Long countMonthlyAnalysesByUserId(
+            Long userId,
+            LocalDateTime startOfMonth,
+            LocalDateTime startOfNextMonth
+    );
+
+    @Query("""
+        select ar
+        from ContractAnalysisResult ar
+        join fetch ar.contract c
+        where c.user.userId = :userId
+        order by ar.createdAt desc
+    """)
+    List<ContractAnalysisResult> findRecentAnalysesByUserId(
+            Long userId,
+            Pageable pageable
+    );
 }

--- a/backend/src/main/java/com/safesign/backend/domain/contract/repository/ContractRepository.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/repository/ContractRepository.java
@@ -23,4 +23,6 @@ public interface ContractRepository extends JpaRepository<Contract, Long> {
             Long userId,
             String keyword
     );
+
+    Long countByUser_UserId(Long userId);
 }

--- a/backend/src/main/java/com/safesign/backend/domain/dashboard/controller/DashboardController.java
+++ b/backend/src/main/java/com/safesign/backend/domain/dashboard/controller/DashboardController.java
@@ -1,0 +1,25 @@
+package com.safesign.backend.domain.dashboard.controller;
+
+import com.safesign.backend.domain.dashboard.dto.response.DashboardResponse;
+import com.safesign.backend.domain.dashboard.service.DashboardService;
+import com.safesign.backend.global.auth.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/dashboard")
+@RequiredArgsConstructor
+public class DashboardController {
+
+    private final DashboardService dashboardService;
+
+    @GetMapping
+    public DashboardResponse getDashboard(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        return dashboardService.getDashboard(userDetails.getUserId());
+    }
+}

--- a/backend/src/main/java/com/safesign/backend/domain/dashboard/dto/response/DashboardResponse.java
+++ b/backend/src/main/java/com/safesign/backend/domain/dashboard/dto/response/DashboardResponse.java
@@ -1,0 +1,15 @@
+package com.safesign.backend.domain.dashboard.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class DashboardResponse {
+
+    private DashboardUserResponse user;
+    private DashboardSummaryResponse summary;
+    private List<RecentContractResponse> recentContracts;
+}

--- a/backend/src/main/java/com/safesign/backend/domain/dashboard/dto/response/DashboardSummaryResponse.java
+++ b/backend/src/main/java/com/safesign/backend/domain/dashboard/dto/response/DashboardSummaryResponse.java
@@ -1,0 +1,13 @@
+package com.safesign.backend.domain.dashboard.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DashboardSummaryResponse {
+
+    private Long totalContracts;
+    private Long riskyContracts;
+    private Long monthlyAnalyses;
+}

--- a/backend/src/main/java/com/safesign/backend/domain/dashboard/dto/response/DashboardUserResponse.java
+++ b/backend/src/main/java/com/safesign/backend/domain/dashboard/dto/response/DashboardUserResponse.java
@@ -1,0 +1,12 @@
+package com.safesign.backend.domain.dashboard.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DashboardUserResponse {
+
+    private Long userId;
+    private String name;
+}

--- a/backend/src/main/java/com/safesign/backend/domain/dashboard/dto/response/RecentContractResponse.java
+++ b/backend/src/main/java/com/safesign/backend/domain/dashboard/dto/response/RecentContractResponse.java
@@ -1,0 +1,17 @@
+package com.safesign.backend.domain.dashboard.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class RecentContractResponse {
+
+    private Long contractId;
+    private String title;
+    private LocalDateTime analyzedAt;
+    private Integer riskScore;
+    private Integer riskCount;
+}

--- a/backend/src/main/java/com/safesign/backend/domain/dashboard/repository/ContractRepository.java
+++ b/backend/src/main/java/com/safesign/backend/domain/dashboard/repository/ContractRepository.java
@@ -1,0 +1,4 @@
+package com.safesign.backend.domain.dashboard.repository;
+
+public class ContractRepository {
+}

--- a/backend/src/main/java/com/safesign/backend/domain/dashboard/service/DashboardService.java
+++ b/backend/src/main/java/com/safesign/backend/domain/dashboard/service/DashboardService.java
@@ -1,0 +1,94 @@
+package com.safesign.backend.domain.dashboard.service;
+
+import com.safesign.backend.domain.contract.entity.ContractAnalysisResult;
+import com.safesign.backend.domain.contract.repository.ContractAnalysisResultRepository;
+import com.safesign.backend.domain.contract.repository.ContractRepository;
+import com.safesign.backend.domain.dashboard.dto.response.DashboardResponse;
+import com.safesign.backend.domain.dashboard.dto.response.DashboardSummaryResponse;
+import com.safesign.backend.domain.dashboard.dto.response.DashboardUserResponse;
+import com.safesign.backend.domain.dashboard.dto.response.RecentContractResponse;
+import com.safesign.backend.domain.user.entity.User;
+import com.safesign.backend.domain.user.repository.UserRepository;
+import com.safesign.backend.global.exception.CustomException;
+import com.safesign.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DashboardService {
+
+    private static final int RISKY_SCORE_THRESHOLD = 70;
+
+    private final UserRepository userRepository;
+    private final ContractRepository contractRepository;
+    private final ContractAnalysisResultRepository contractAnalysisResultRepository;
+
+    public DashboardResponse getDashboard(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        Long totalContracts = contractRepository.countByUser_UserId(userId);
+        Long riskyContracts = contractAnalysisResultRepository
+                .countRiskyAnalysesByUserId(userId, RISKY_SCORE_THRESHOLD);
+
+        LocalDate now = LocalDate.now();
+        LocalDateTime startOfMonth = now.withDayOfMonth(1).atStartOfDay();
+        LocalDateTime startOfNextMonth = startOfMonth.plusMonths(1);
+
+        Long monthlyAnalyses = contractAnalysisResultRepository.countMonthlyAnalysesByUserId(
+                userId,
+                startOfMonth,
+                startOfNextMonth
+        );
+
+        List<RecentContractResponse> recentContracts =
+                contractAnalysisResultRepository.findRecentAnalysesByUserId(
+                                userId,
+                                PageRequest.of(0, 3)
+                        )
+                        .stream()
+                        .map(this::toRecentContractResponse)
+                        .toList();
+
+        return DashboardResponse.builder()
+                .user(DashboardUserResponse.builder()
+                        .userId(user.getUserId())
+                        .name(user.getName())
+                        .build())
+                .summary(DashboardSummaryResponse.builder()
+                        .totalContracts(totalContracts)
+                        .riskyContracts(riskyContracts)
+                        .monthlyAnalyses(monthlyAnalyses)
+                        .build())
+                .recentContracts(recentContracts)
+                .build();
+    }
+
+    private RecentContractResponse toRecentContractResponse(ContractAnalysisResult analysisResult) {
+        Integer riskScore = analysisResult.getOverallRiskScore();
+
+        return RecentContractResponse.builder()
+                .contractId(analysisResult.getContract().getContractId())
+                .title(analysisResult.getContract().getTitle())
+                .analyzedAt(analysisResult.getCreatedAt())
+                .riskScore(riskScore)
+                .riskCount(countRiskTypes(analysisResult.getRiskTypes()))
+                .build();
+    }
+
+    private Integer countRiskTypes(String riskTypes) {
+        if (riskTypes == null || riskTypes.isBlank()) {
+            return 0;
+        }
+
+        return riskTypes.split(",").length;
+    }
+}

--- a/backend/src/main/java/com/safesign/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/safesign/backend/global/config/SecurityConfig.java
@@ -56,25 +56,27 @@ public class SecurityConfig {
                                 "/oauth2/**",
                                 "/login/**",
 
-                                "/favicon.ico",
-
                                 "/api/v1/auth/reissue",
 
-                                "/api/v1/admin/auth/**"
+                                "/api/v1/admin/auth/**",
+
+                                "/favicon.ico"
                         ).permitAll()
+
+                        .requestMatchers("/api/v1/auth/**")
+                        .authenticated()
 
                         .requestMatchers("/api/v1/users/**")
                         .authenticated()
 
-                        // 관리자 전용
-                        .requestMatchers("/api/v1/admin/**")
-                        .authenticated()
-
-                        // 로그인 사용자
-                        .requestMatchers("/api/v1/auth/**")
+                        .requestMatchers("/api/v1/dashboard/**")
                         .authenticated()
 
                         .requestMatchers("/api/v1/contracts/**")
+                        .authenticated()
+
+                        // 관리자 전용
+                        .requestMatchers("/api/v1/admin/**")
                         .authenticated()
 
                         .anyRequest()


### PR DESCRIPTION
## 🧾 PR 제목
[Feat/#40] 메인 대시보드 api 구현 

---

## 📌 관련 이슈
- Closes #40 

---

## ✨ PR 유형
- [0] 신규 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명 필요)

---

## 📋 작업 내용
- 대시보드 조회 API 구현
- 사용자 정보 조회 기능 추가
- 전체 계약서 수 / 위험 계약서 수 / 이번 달 분석 수 조회 기능 구현
- 최근 분석 계약서 3건 조회 기능 구현
- Dashboard DTO 및 Service 추가

---

## 🔍 변경 사항
- `/api/v1/dashboard` API 추가
- Dashboard Controller / Service / DTO 추가
- ContractRepository count 쿼리 추가
- ContractAnalysisResultRepository 통계 및 최근 분석 조회 쿼리 추가
- 사용자별 계약서 및 분석 결과 조회 로직 구현

---

## 🧪 테스트
- [0] 로컬 실행 확인
- [0] DB 연결 확인
- [0] API 정상 동작 확인 (Swagger 등)
- [ ] 기타 테스트:

---

## ⚠️ 주의 사항 (중요)
- 환경변수 변경 여부
- DB 구조 변경 여부
- 팀원에게 영향 있는 부분

---

## 📸 스크린샷 (선택)
- UI 변경 시 첨부

---

## 🔗 참고 자료
- 관련 문서 / 링크

---

## 📌 리뷰 요구 사항
- 집중적으로 봐야 할 부분
- 고민했던 부분

---

## 📌 PR 규칙
- 최소 1명 이상 승인 후 merge
- main 직접 push 금지
- dev 또는 feature 브랜치 사용