### PR TITLE
[Feat/#44] OCR 완료 후 AI 계약서 분석 결과 저장 연동

### DIFF
--- a/backend/src/main/java/com/safesign/backend/domain/contract/client/AiAnalysisClient.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/client/AiAnalysisClient.java
@@ -1,0 +1,35 @@
+package com.safesign.backend.domain.contract.client;
+
+import com.safesign.backend.domain.contract.dto.response.AiAnalysisResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component
+public class AiAnalysisClient {
+
+    private final RestClient restClient;
+
+    public AiAnalysisClient(
+            @Value("${ai.service.base-url:http://ai-service:8000}") String baseUrl
+    ) {
+        this.restClient = RestClient.builder()
+                .baseUrl(baseUrl)
+                .build();
+    }
+
+    public AiAnalysisResponse analyzeFromOcr(Long contractId, String authorization) {
+        RestClient.RequestBodySpec request = restClient.post()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/analyze_from_ocr/{contractId}")
+                        .queryParam("explain", true)
+                        .build(contractId));
+
+        if (authorization != null && !authorization.isBlank()) {
+            request.header(HttpHeaders.AUTHORIZATION, authorization);
+        }
+
+        return request.retrieve().body(AiAnalysisResponse.class);
+    }
+}

--- a/backend/src/main/java/com/safesign/backend/domain/contract/controller/ContractParsingController.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/controller/ContractParsingController.java
@@ -1,7 +1,7 @@
 package com.safesign.backend.domain.contract.controller;
 
-import com.safesign.backend.domain.contract.service.ContractParsingService;
 import com.safesign.backend.domain.contract.dto.response.ParsingResponse;
+import com.safesign.backend.domain.contract.service.ContractParsingService;
 import com.safesign.backend.global.auth.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -14,7 +14,10 @@ public class ContractParsingController {
 
     private final ContractParsingService parsingService;
 
-    @PostMapping("/{contractId}/parse")
+    @RequestMapping(
+            value = "/{contractId}/parse",
+            method = {RequestMethod.GET, RequestMethod.POST}
+    )
     public ParsingResponse parseContract(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long contractId

--- a/backend/src/main/java/com/safesign/backend/domain/contract/dto/response/AiAnalysisResponse.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/dto/response/AiAnalysisResponse.java
@@ -1,0 +1,81 @@
+package com.safesign.backend.domain.contract.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AiAnalysisResponse {
+
+    private Long contractId;
+
+    @JsonProperty("overall_analysis")
+    private OverallAnalysis overallAnalysis;
+
+    @JsonProperty("recommended_special_clauses")
+    private List<RecommendedSpecialClause> recommendedSpecialClauses = new ArrayList<>();
+
+    @JsonProperty("clause_analyses")
+    private List<ClauseAnalysis> clauseAnalyses = new ArrayList<>();
+
+    @JsonProperty("processing_time_ms")
+    private Long processingTimeMs;
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class OverallAnalysis {
+        @JsonProperty("overall_risk_score")
+        private Integer overallRiskScore;
+        @JsonProperty("risk_types")
+        private List<String> riskTypes = new ArrayList<>();
+        private String summary;
+        private Integer percentile;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class RecommendedSpecialClause {
+        private String title;
+        private String content;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class ClauseAnalysis {
+        @JsonProperty("clause_id")
+        private Long clauseId;
+        @JsonProperty("article_no")
+        private String articleNo;
+        private String title;
+        @JsonProperty("clause_type")
+        private String clauseType;
+        private String content;
+        @JsonProperty("risk_type")
+        private List<String> riskType = new ArrayList<>();
+        @JsonProperty("risk_score")
+        private Integer riskScore;
+        @JsonProperty("related_clauses")
+        private List<String> relatedClauses = new ArrayList<>();
+        private String reason;
+        @JsonProperty("related_laws")
+        private List<RelatedLaw> relatedLaws = new ArrayList<>();
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class RelatedLaw {
+        @JsonProperty("law_name")
+        private String lawName;
+        private String article;
+    }
+}

--- a/backend/src/main/java/com/safesign/backend/domain/contract/repository/ContractClauseRepository.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/repository/ContractClauseRepository.java
@@ -4,8 +4,16 @@ import com.safesign.backend.domain.contract.entity.Contract;
 import com.safesign.backend.domain.contract.entity.ContractClause;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ContractClauseRepository
         extends JpaRepository<ContractClause, Long> {
 
     void deleteByContract(Contract contract);
+
+    Optional<ContractClause> findFirstByContract_ContractIdAndClauseNoAndClauseText(
+            Long contractId,
+            String clauseNo,
+            String clauseText
+    );
 }

--- a/backend/src/main/java/com/safesign/backend/domain/contract/service/ContractAiAnalysisService.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/service/ContractAiAnalysisService.java
@@ -1,0 +1,37 @@
+package com.safesign.backend.domain.contract.service;
+
+import com.safesign.backend.domain.contract.client.AiAnalysisClient;
+import com.safesign.backend.domain.contract.dto.response.AiAnalysisResponse;
+import com.safesign.backend.global.exception.CustomException;
+import com.safesign.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ContractAiAnalysisService {
+
+    private final AiAnalysisClient aiAnalysisClient;
+    private final ContractAnalysisPersistenceService persistenceService;
+
+    public void analyzeFromOcr(Long userId, Long contractId, String authorization) {
+        persistenceService.markProcessing(userId, contractId);
+
+        try {
+            AiAnalysisResponse response =
+                    aiAnalysisClient.analyzeFromOcr(contractId, authorization);
+
+            if (response == null || response.getOverallAnalysis() == null) {
+                throw new IllegalStateException("AI analysis response is empty.");
+            }
+
+            persistenceService.saveCompletedResult(userId, contractId, response);
+        } catch (Exception e) {
+            log.error("AI analysis failed - contractId={}", contractId, e);
+            persistenceService.markFailed(userId, contractId);
+            throw new CustomException(ErrorCode.AI_ANALYSIS_FAILED);
+        }
+    }
+}

--- a/backend/src/main/java/com/safesign/backend/domain/contract/service/ContractAnalysisPersistenceService.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/service/ContractAnalysisPersistenceService.java
@@ -1,0 +1,139 @@
+package com.safesign.backend.domain.contract.service;
+
+import com.safesign.backend.domain.contract.dto.response.AiAnalysisResponse;
+import com.safesign.backend.domain.contract.entity.Contract;
+import com.safesign.backend.domain.contract.entity.ContractAnalysisResult;
+import com.safesign.backend.domain.contract.entity.ContractClause;
+import com.safesign.backend.domain.contract.entity.ContractClauseAnalysis;
+import com.safesign.backend.domain.contract.entity.ContractClauseRelatedLaw;
+import com.safesign.backend.domain.contract.entity.ContractRecommendedSpecialClause;
+import com.safesign.backend.domain.contract.enums.ContractStatus;
+import com.safesign.backend.domain.contract.repository.ContractAnalysisResultRepository;
+import com.safesign.backend.domain.contract.repository.ContractClauseRepository;
+import com.safesign.backend.domain.contract.repository.ContractRepository;
+import com.safesign.backend.global.exception.CustomException;
+import com.safesign.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ContractAnalysisPersistenceService {
+
+    private final ContractRepository contractRepository;
+    private final ContractClauseRepository contractClauseRepository;
+    private final ContractAnalysisResultRepository analysisResultRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markProcessing(Long userId, Long contractId) {
+        Contract contract = getContract(userId, contractId);
+        contract.updateStatus(ContractStatus.AI_PROCESSING);
+        contract.updateFailureReason(null);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markFailed(Long userId, Long contractId) {
+        Contract contract = getContract(userId, contractId);
+        contract.updateStatus(ContractStatus.AI_FAILED);
+        contract.updateFailureReason("AI analysis process failed.");
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void saveCompletedResult(Long userId, Long contractId, AiAnalysisResponse response) {
+        Contract contract = getContract(userId, contractId);
+        AiAnalysisResponse.OverallAnalysis overall = response.getOverallAnalysis();
+
+        ContractAnalysisResult result = ContractAnalysisResult.builder()
+                .contract(contract)
+                .overallRiskScore(resolveRiskScore(overall))
+                .riskTypes(join(overall.getRiskTypes()))
+                .summary(overall.getSummary())
+                .analysisTimeSeconds(toSeconds(response.getProcessingTimeMs()))
+                .build();
+
+        for (AiAnalysisResponse.RecommendedSpecialClause clause :
+                safe(response.getRecommendedSpecialClauses())) {
+            result.addRecommendedSpecialClause(ContractRecommendedSpecialClause.builder()
+                    .title(clause.getTitle())
+                    .content(clause.getContent())
+                    .build());
+        }
+
+        List<AiAnalysisResponse.ClauseAnalysis> clauses = safe(response.getClauseAnalyses());
+        for (int index = 0; index < clauses.size(); index++) {
+            AiAnalysisResponse.ClauseAnalysis clause = clauses.get(index);
+            ContractClause originalClause = findOrCreateContractClause(contract, clause, index);
+            ContractClauseAnalysis analysis = ContractClauseAnalysis.builder()
+                    .originalClause(originalClause)
+                    .articleNo(clause.getArticleNo())
+                    .title(clause.getTitle())
+                    .clauseType(clause.getClauseType())
+                    .content(clause.getContent())
+                    .riskType(join(clause.getRiskType()))
+                    .riskScore(clause.getRiskScore())
+                    .relatedClauses(join(clause.getRelatedClauses()))
+                    .reason(clause.getReason())
+                    .build();
+
+            for (AiAnalysisResponse.RelatedLaw law : safe(clause.getRelatedLaws())) {
+                analysis.addRelatedLaw(ContractClauseRelatedLaw.builder()
+                        .lawName(law.getLawName())
+                        .article(law.getArticle())
+                        .build());
+            }
+
+            result.addClauseAnalysis(analysis);
+        }
+
+        analysisResultRepository.save(result);
+        contract.updateStatus(ContractStatus.AI_COMPLETED);
+        contract.updateFailureReason(null);
+    }
+
+    private ContractClause findOrCreateContractClause(
+            Contract contract,
+            AiAnalysisResponse.ClauseAnalysis clause,
+            int index
+    ) {
+        return contractClauseRepository
+                .findFirstByContract_ContractIdAndClauseNoAndClauseText(
+                        contract.getContractId(),
+                        clause.getArticleNo(),
+                        clause.getContent())
+                .orElseGet(() -> contractClauseRepository.save(ContractClause.builder()
+                        .contract(contract)
+                        .clauseNo(clause.getArticleNo())
+                        .clauseTitle(clause.getTitle())
+                        .clauseText(clause.getContent())
+                        .clauseType(clause.getClauseType())
+                        .orderNo(index + 1)
+                        .build()));
+    }
+
+    private Contract getContract(Long userId, Long contractId) {
+        return contractRepository.findByContractIdAndUser_UserId(contractId, userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.CONTRACT_NOT_FOUND));
+    }
+
+    private Integer resolveRiskScore(AiAnalysisResponse.OverallAnalysis overall) {
+        return overall.getPercentile() != null
+                ? overall.getPercentile()
+                : overall.getOverallRiskScore();
+    }
+
+    private String join(List<String> values) {
+        return values == null || values.isEmpty() ? null : String.join(",", values);
+    }
+
+    private Double toSeconds(Long processingTimeMs) {
+        return processingTimeMs == null ? null : processingTimeMs / 1000.0;
+    }
+
+    private <T> List<T> safe(List<T> values) {
+        return values == null ? List.of() : values;
+    }
+}

--- a/backend/src/main/java/com/safesign/backend/domain/ocr/controller/OcrController.java
+++ b/backend/src/main/java/com/safesign/backend/domain/ocr/controller/OcrController.java
@@ -1,13 +1,20 @@
 package com.safesign.backend.domain.ocr.controller;
 
+import com.safesign.backend.domain.contract.service.ContractAiAnalysisService;
 import com.safesign.backend.domain.ocr.dto.response.OcrResponse;
 import com.safesign.backend.domain.ocr.service.OcrQueryService;
 import com.safesign.backend.domain.ocr.service.OcrService;
 import com.safesign.backend.global.auth.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -16,14 +23,23 @@ public class OcrController {
 
     private final OcrService ocrService;
     private final OcrQueryService ocrQueryService;
+    private final ContractAiAnalysisService contractAiAnalysisService;
 
     @PostMapping("/{contractId}/ocr")
     public ResponseEntity<String> processOcr(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @PathVariable Long contractId
+            @PathVariable Long contractId,
+            @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authorization
     ) {
         ocrService.process(userDetails.getUserId(), contractId);
-        return ResponseEntity.ok("OCR 처리가 완료되었습니다.");
+
+        contractAiAnalysisService.analyzeFromOcr(
+                userDetails.getUserId(),
+                contractId,
+                authorization
+        );
+
+        return ResponseEntity.ok("OCR 및 AI 분석 처리가 완료되었습니다.");
     }
 
     @GetMapping("/{contractId}/ocr")

--- a/backend/src/main/java/com/safesign/backend/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/safesign/backend/global/exception/ErrorCode.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ErrorCode {
 
+    AI_ANALYSIS_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AI 분석 중 오류가 발생했습니다."),
     CONTRACT_NOT_FOUND(HttpStatus.NOT_FOUND, "계약서를 찾을 수 없습니다."),
     CONTRACT_FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "계약서 파일을 찾을 수 없습니다."),
     OCR_RESULT_NOT_FOUND(HttpStatus.NOT_FOUND, "OCR 결과를 찾을 수 없습니다."),

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -84,3 +84,7 @@ aws:
     bucket: ${AWS_S3_BUCKET}
     region: ${AWS_REGION}
     base-prefix: ${AWS_S3_BASE_PREFIX}
+
+ai:
+  service:
+    base-url: ${AI_SERVICE_BASE_URL:https://safesign-ai.site/ai-docs}


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #44

---

## ✨ PR 유형
- [x] 신규 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명 필요)

---

## 📋 작업 내용
- OCR 완료 후 AI 분석 API를 호출하도록 연동했습니다.
- AI 분석 결과를 계약서 분석 관련 테이블에 저장하도록 구현했습니다.
- AI가 조회하는 계약서 파싱 API에 `GET` 요청을 허용했습니다.
- AI 분석 상태를 `AI_PROCESSING`, `AI_COMPLETED`, `AI_FAILED`로 관리하도록 구현했습니다.

---

## 🔍 변경 사항
- `POST /analyze_from_ocr/{contractId}` AI 호출 및 Authorization 헤더 전달
- AI 응답의 `percentile` 값을 전체 위험도 점수로 저장
- 추천 특약, 조항별 분석 결과, 관련 법률 저장
- `GET /api/v1/contracts/{contractId}/parse` 지원 추가
- `AI_SERVICE_BASE_URL` 설정 추가

추가/수정 파일:
- `AiAnalysisClient.java`
- `AiAnalysisResponse.java`
- `ContractAiAnalysisService.java`
- `ContractAnalysisPersistenceService.java`
- `OcrController.java`
- `ContractParsingController.java`
- `ContractClauseRepository.java`
- `ErrorCode.java`
- `application.yml`

---

## 🧪 테스트
- [x] 로컬 컴파일 확인 (`./gradlew compileJava`)
- [x] DB 연결 및 OCR 결과 저장 확인
- [ ] 배포 환경 AI 연동 정상 동작 확인
- [ ] AI 분석 결과 DB 저장 확인

---

## ⚠️ 주의 사항 (중요)
- 배포 AI는 배포 백엔드를 조회하므로 최종 통합 테스트는 배포 환경에서 진행해야 합니다.
- 현재 동일 계약서 재분석은 기존 조항 삭제/재생성으로 인해 참조 관계 검토가 필요합니다.

---

## 🔗 참고 자료
- AI Swagger: https://safesign-ai.site/ai-docs/docs#/
- AI 호출 API: `POST /analyze_from_ocr/{contractId}`

---

## 📌 리뷰 요구 사항

---

## 📌 PR 규칙
- 최소 1명 이상 승인 후 merge
- main 직접 push 금지
- dev 또는 feature 브랜치 사용