### PR TITLE
refactor: allow local frontend cors origin

### DIFF
--- a/backend/src/main/java/com/safesign/backend/global/config/CorsConfig.java
+++ b/backend/src/main/java/com/safesign/backend/global/config/CorsConfig.java
@@ -12,6 +12,9 @@ public class CorsConfig {
     @Value("${app.frontend-url}")
     private String frontendUrl;
 
+    @Value("${app.local-frontend-url:http://localhost:3000}")
+    private String localFrontendUrl;
+
     @Bean
     public WebMvcConfigurer corsConfigurer() {
         return new WebMvcConfigurer() {
@@ -19,7 +22,7 @@ public class CorsConfig {
             @Override
             public void addCorsMappings(CorsRegistry registry) {
                 registry.addMapping("/**")
-                        .allowedOrigins(frontendUrl)
+                        .allowedOrigins(frontendUrl, localFrontendUrl)
                         .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
                         .allowedHeaders("*")
                         .allowCredentials(true);

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -74,6 +74,7 @@ jwt:
 
 app:
   frontend-url: ${FRONTEND_URL}
+  local-frontend-url: ${LOCAL_FRONTEND_URL:http://localhost:3000}
 
   cookie:
     secure: ${COOKIE_SECURE}


### PR DESCRIPTION
## 🧾 PR 제목
[Feat/#46] 로컬 프론트엔드 CORS 허용 설정

---

## 📌 관련 이슈
- Closes #46 

---

## ✨ PR 유형
- [ ] 신규 기능
- [ ] 버그 수정
- [0] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명 필요)

---

## 📋 작업 내용
- 로컬 프론트엔드(http://localhost:3000) API 연동을 위한 CORS 설정 추가
- 기존 단일 Origin 허용 구조를 다중 Origin 허용 구조로 개선
- 배포 프론트와 로컬 프론트 환경을 동시에 지원하도록 수정

---

## 🔍 변경 사항
- CorsConfig의 allowedOrigins 다중 설정 지원
- local-frontend-url 환경변수 추가
- allowCredentials(true) 유지하여 refreshToken 쿠키 기반 인증 구조 지원
수정 파일:
CorsConfig.java
application.yml

---

## 🧪 테스트
- [0] 로컬 실행 확인
- [0] DB 연결 확인
- [0] API 정상 동작 확인 (Swagger 등)
- [ ] 기타 테스트: 배포 환경 연동은 확인 해봐야됨

---

## ⚠️ 주의 사항 (중요)
- .env에 LOCAL_FRONTEND_URL 환경변수 추가 필요
- 프론트 요청 시 withCredentials: true 필요
- allowCredentials(true) 사용으로 인해 allowedOrigins("*") 사용 불가

---

## 📸 스크린샷 (선택)
- UI 변경 시 첨부

---

## 🔗 참고 자료
- 관련 문서 / 링크

---

## 📌 리뷰 요구 사항
- 집중적으로 봐야 할 부분
- 고민했던 부분

---

## 📌 PR 규칙
- 최소 1명 이상 승인 후 merge
- main 직접 push 금지
- dev 또는 feature 브랜치 사용