### PR TITLE
[Feat] 계약서 AI 분석 결과 조회 API 추가

### DIFF
--- a/backend/src/main/java/com/safesign/backend/domain/contract/controller/ContractController.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/controller/ContractController.java
@@ -2,9 +2,11 @@ package com.safesign.backend.domain.contract.controller;
 
 import com.safesign.backend.domain.contract.dto.response.ContractUploadResponse;
 import com.safesign.backend.domain.contract.dto.response.ContractListResponse;
+import com.safesign.backend.domain.contract.dto.response.ContractAnalysisResponse;
 import com.safesign.backend.domain.contract.enums.UploadType;
 import com.safesign.backend.domain.contract.service.ContractService;
 import com.safesign.backend.domain.contract.service.ContractQueryService;
+import com.safesign.backend.domain.contract.service.ContractAnalysisQueryService;
 import com.safesign.backend.global.auth.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -22,6 +24,7 @@ public class ContractController {
 
     private final ContractService contractService;
     private final ContractQueryService contractQueryService;
+    private final ContractAnalysisQueryService contractAnalysisQueryService;
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @ResponseStatus(HttpStatus.CREATED)
@@ -45,6 +48,17 @@ public class ContractController {
         Long userId = userDetails.getUserId();
 
         return contractQueryService.getContracts(userId, keyword, sort);
+    }
+
+    @GetMapping("/{contractId}/analysis")
+    public ContractAnalysisResponse getAnalysisResult(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long contractId
+    ) {
+        return contractAnalysisQueryService.getAnalysisResult(
+                userDetails.getUserId(),
+                contractId
+        );
     }
 
     @DeleteMapping("/{contractId}")

--- a/backend/src/main/java/com/safesign/backend/domain/contract/controller/ContractParsingController.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/controller/ContractParsingController.java
@@ -1,6 +1,7 @@
 package com.safesign.backend.domain.contract.controller;
 
 import com.safesign.backend.domain.contract.dto.response.ParsingResponse;
+import com.safesign.backend.domain.contract.service.ContractParsingQueryService;
 import com.safesign.backend.domain.contract.service.ContractParsingService;
 import com.safesign.backend.global.auth.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
@@ -13,16 +14,27 @@ import org.springframework.web.bind.annotation.*;
 public class ContractParsingController {
 
     private final ContractParsingService parsingService;
+    private final ContractParsingQueryService parsingQueryService;
 
-    @RequestMapping(
-            value = "/{contractId}/parse",
-            method = {RequestMethod.GET, RequestMethod.POST}
-    )
-    public ParsingResponse parseContract(
+    // 저장용: OCR 결과를 파싱해서 DB 저장
+    @PostMapping("/{contractId}/parse")
+    public ParsingResponse parseAndSaveContract(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long contractId
     ) {
         return parsingService.parse(
+                userDetails.getUserId(),
+                contractId
+        );
+    }
+
+    // 조회용: 이미 DB에 저장된 파싱 결과만 조회
+    @GetMapping("/{contractId}/parse")
+    public ParsingResponse getParsedContract(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long contractId
+    ) {
+        return parsingQueryService.getParsedResult(
                 userDetails.getUserId(),
                 contractId
         );

--- a/backend/src/main/java/com/safesign/backend/domain/contract/dto/response/ContractAnalysisResponse.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/dto/response/ContractAnalysisResponse.java
@@ -1,0 +1,58 @@
+package com.safesign.backend.domain.contract.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class ContractAnalysisResponse {
+
+    private Long contractId;
+    private LocalDateTime analyzedAt;
+    private OverallAnalysisResponse overallAnalysis;
+    private List<RecommendedSpecialClauseResponse> recommendedSpecialClauses;
+    private List<ClauseAnalysisResponse> clauseAnalyses;
+
+    @Getter
+    @Builder
+    public static class OverallAnalysisResponse {
+
+        private Integer overallRiskScore;
+        private List<String> riskTypes;
+        private String summary;
+    }
+
+    @Getter
+    @Builder
+    public static class RecommendedSpecialClauseResponse {
+
+        private String title;
+        private String content;
+    }
+
+    @Getter
+    @Builder
+    public static class ClauseAnalysisResponse {
+
+        private String articleNo;
+        private String title;
+        private String clauseType;
+        private String content;
+        private List<String> riskTypes;
+        private Integer riskScore;
+        private List<String> relatedClauses;
+        private String reason;
+        private List<RelatedLawResponse> relatedLaws;
+    }
+
+    @Getter
+    @Builder
+    public static class RelatedLawResponse {
+
+        private String lawName;
+        private String article;
+    }
+}

--- a/backend/src/main/java/com/safesign/backend/domain/contract/repository/ContractClauseRepository.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/repository/ContractClauseRepository.java
@@ -4,6 +4,7 @@ import com.safesign.backend.domain.contract.entity.Contract;
 import com.safesign.backend.domain.contract.entity.ContractClause;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ContractClauseRepository
@@ -16,4 +17,6 @@ public interface ContractClauseRepository
             String clauseNo,
             String clauseText
     );
+
+    List<ContractClause> findByContractOrderByOrderNoAsc(Contract contract);
 }

--- a/backend/src/main/java/com/safesign/backend/domain/contract/repository/ContractHeaderInfoRepository.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/repository/ContractHeaderInfoRepository.java
@@ -4,8 +4,12 @@ import com.safesign.backend.domain.contract.entity.Contract;
 import com.safesign.backend.domain.contract.entity.ContractHeaderInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ContractHeaderInfoRepository
         extends JpaRepository<ContractHeaderInfo, Long> {
 
     void deleteByContract(Contract contract);
+
+    List<ContractHeaderInfo> findByContract(Contract contract);
 }

--- a/backend/src/main/java/com/safesign/backend/domain/contract/repository/ContractOcrResultRepository.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/repository/ContractOcrResultRepository.java
@@ -3,18 +3,10 @@ package com.safesign.backend.domain.contract.repository;
 import com.safesign.backend.domain.contract.entity.Contract;
 import com.safesign.backend.domain.contract.entity.ContractOcrResult;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface ContractOcrResultRepository extends JpaRepository<ContractOcrResult, Long> {
 
-    @Query("""
-        SELECT o
-        FROM ContractOcrResult o
-        WHERE o.contract = :contract
-        ORDER BY o.ocrResultId DESC
-    """)
-    Optional<ContractOcrResult> findLatestOcrResult(@Param("contract") Contract contract);
+    Optional<ContractOcrResult> findFirstByContractOrderByOcrResultIdDesc(Contract contract);
 }

--- a/backend/src/main/java/com/safesign/backend/domain/contract/service/ContractAiAnalysisService.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/service/ContractAiAnalysisService.java
@@ -6,7 +6,9 @@ import com.safesign.backend.global.exception.CustomException;
 import com.safesign.backend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientResponseException;
 
 @Slf4j
 @Service
@@ -15,6 +17,9 @@ public class ContractAiAnalysisService {
 
     private final AiAnalysisClient aiAnalysisClient;
     private final ContractAnalysisPersistenceService persistenceService;
+
+    @Value("${ai.debug.expose-error:false}")
+    private boolean exposeAiError;
 
     public void analyzeFromOcr(Long userId, Long contractId, String authorization) {
         persistenceService.markProcessing(userId, contractId);
@@ -28,10 +33,30 @@ public class ContractAiAnalysisService {
             }
 
             persistenceService.saveCompletedResult(userId, contractId, response);
+        } catch (RestClientResponseException e) {
+            log.error(
+                    "AI analysis API failed - contractId={}, status={}, responseBody={}",
+                    contractId,
+                    e.getStatusCode(),
+                    e.getResponseBodyAsString(),
+                    e
+            );
+            persistenceService.markFailed(userId, contractId);
+            throw toAnalysisException(
+                    "AI API " + e.getStatusCode() + ": " + e.getResponseBodyAsString()
+            );
         } catch (Exception e) {
             log.error("AI analysis failed - contractId={}", contractId, e);
             persistenceService.markFailed(userId, contractId);
-            throw new CustomException(ErrorCode.AI_ANALYSIS_FAILED);
+            throw toAnalysisException(e.getMessage());
         }
+    }
+
+    private CustomException toAnalysisException(String detail) {
+        if (exposeAiError && detail != null && !detail.isBlank()) {
+            return new CustomException(ErrorCode.AI_ANALYSIS_FAILED, detail);
+        }
+
+        return new CustomException(ErrorCode.AI_ANALYSIS_FAILED);
     }
 }

--- a/backend/src/main/java/com/safesign/backend/domain/contract/service/ContractAnalysisQueryService.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/service/ContractAnalysisQueryService.java
@@ -1,0 +1,87 @@
+package com.safesign.backend.domain.contract.service;
+
+import com.safesign.backend.domain.contract.dto.response.ContractAnalysisResponse;
+import com.safesign.backend.domain.contract.entity.ContractAnalysisResult;
+import com.safesign.backend.domain.contract.entity.ContractClauseAnalysis;
+import com.safesign.backend.domain.contract.repository.ContractAnalysisResultRepository;
+import com.safesign.backend.domain.contract.repository.ContractRepository;
+import com.safesign.backend.global.exception.CustomException;
+import com.safesign.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ContractAnalysisQueryService {
+
+    private final ContractRepository contractRepository;
+    private final ContractAnalysisResultRepository analysisResultRepository;
+
+    public ContractAnalysisResponse getAnalysisResult(Long userId, Long contractId) {
+        contractRepository.findByContractIdAndUser_UserId(contractId, userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.CONTRACT_NOT_FOUND));
+
+        ContractAnalysisResult result = analysisResultRepository
+                .findTopByContract_ContractIdOrderByCreatedAtDesc(contractId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ANALYSIS_RESULT_NOT_FOUND));
+
+        return ContractAnalysisResponse.builder()
+                .contractId(contractId)
+                .analyzedAt(result.getCreatedAt())
+                .overallAnalysis(ContractAnalysisResponse.OverallAnalysisResponse.builder()
+                        .overallRiskScore(result.getOverallRiskScore())
+                        .riskTypes(split(result.getRiskTypes()))
+                        .summary(result.getSummary())
+                        .build())
+                .recommendedSpecialClauses(result.getRecommendedSpecialClauses()
+                        .stream()
+                        .map(clause -> ContractAnalysisResponse.RecommendedSpecialClauseResponse.builder()
+                                .title(clause.getTitle())
+                                .content(clause.getContent())
+                                .build())
+                        .toList())
+                .clauseAnalyses(result.getClauseAnalyses()
+                        .stream()
+                        .map(this::toClauseAnalysisResponse)
+                        .toList())
+                .build();
+    }
+
+    private ContractAnalysisResponse.ClauseAnalysisResponse toClauseAnalysisResponse(
+            ContractClauseAnalysis analysis
+    ) {
+        return ContractAnalysisResponse.ClauseAnalysisResponse.builder()
+                .articleNo(analysis.getArticleNo())
+                .title(analysis.getTitle())
+                .clauseType(analysis.getClauseType())
+                .content(analysis.getContent())
+                .riskTypes(split(analysis.getRiskType()))
+                .riskScore(analysis.getRiskScore())
+                .relatedClauses(split(analysis.getRelatedClauses()))
+                .reason(analysis.getReason())
+                .relatedLaws(analysis.getRelatedLaws()
+                        .stream()
+                        .map(law -> ContractAnalysisResponse.RelatedLawResponse.builder()
+                                .lawName(law.getLawName())
+                                .article(law.getArticle())
+                                .build())
+                        .toList())
+                .build();
+    }
+
+    private List<String> split(String values) {
+        if (values == null || values.isBlank()) {
+            return List.of();
+        }
+
+        return Arrays.stream(values.split(","))
+                .map(String::trim)
+                .filter(value -> !value.isBlank())
+                .toList();
+    }
+}

--- a/backend/src/main/java/com/safesign/backend/domain/contract/service/ContractParsingQueryService.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/service/ContractParsingQueryService.java
@@ -1,0 +1,94 @@
+package com.safesign.backend.domain.contract.service;
+
+import com.safesign.backend.domain.contract.dto.response.ClauseResponse;
+import com.safesign.backend.domain.contract.dto.response.HeaderResponse;
+import com.safesign.backend.domain.contract.dto.response.ParsingResponse;
+import com.safesign.backend.domain.contract.entity.Contract;
+import com.safesign.backend.domain.contract.entity.ContractClause;
+import com.safesign.backend.domain.contract.entity.ContractHeaderInfo;
+import com.safesign.backend.domain.contract.repository.ContractClauseRepository;
+import com.safesign.backend.domain.contract.repository.ContractHeaderInfoRepository;
+import com.safesign.backend.domain.contract.repository.ContractRepository;
+import com.safesign.backend.global.exception.CustomException;
+import com.safesign.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ContractParsingQueryService {
+
+    private final ContractRepository contractRepository;
+    private final ContractClauseRepository clauseRepository;
+    private final ContractHeaderInfoRepository headerRepository;
+
+    public ParsingResponse getParsedResult(Long userId, Long contractId) {
+        Contract contract = contractRepository
+                .findByContractIdAndUser_UserId(contractId, userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.CONTRACT_NOT_FOUND));
+
+        List<ContractClause> clauseEntities = clauseRepository.findByContractOrderByOrderNoAsc(contract);
+
+        if (clauseEntities.isEmpty()) {
+            throw new CustomException(ErrorCode.PARSE_RESULT_NOT_FOUND);
+        }
+
+        List<ClauseResponse> clauses = clauseEntities.stream()
+                .map(clause -> new ClauseResponse(
+                        clause.getClauseTitle(),
+                        clause.getClauseText(),
+                        clause.getOrderNo()
+                ))
+                .toList();
+
+        List<ContractHeaderInfo> headerEntities = headerRepository.findByContract(contract);
+
+        ContractHeaderInfo headerEntity = headerEntities.isEmpty()
+                ? null
+                : headerEntities.get(headerEntities.size() - 1);
+
+        HeaderResponse header = toHeaderResponse(headerEntity);
+
+        return new ParsingResponse(
+                contract.getContractId(),
+                clauses.size(),
+                "파싱 결과 조회 완료",
+                List.of(),
+                clauses,
+                header
+        );
+    }
+
+    private HeaderResponse toHeaderResponse(ContractHeaderInfo header) {
+        if (header == null) {
+            return new HeaderResponse(
+                    null, null, null, null, null, null, null,
+                    null, null, null, null, null, null
+            );
+        }
+
+        return new HeaderResponse(
+                header.getPropertyAddress(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                toStringValue(header.getDepositAmount()),
+                toStringValue(header.getContractPayment()),
+                null,
+                null,
+                toStringValue(header.getMonthlyRent())
+        );
+    }
+
+    private String toStringValue(Long value) {
+        return value == null ? null : String.valueOf(value);
+    }
+}

--- a/backend/src/main/java/com/safesign/backend/domain/contract/service/ContractParsingService.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/service/ContractParsingService.java
@@ -35,7 +35,7 @@ public class ContractParsingService {
                 .orElseThrow(() -> new CustomException(ErrorCode.CONTRACT_NOT_FOUND));
 
         ContractOcrResult ocr = ocrRepository
-                .findLatestOcrResult(contract)
+                .findFirstByContractOrderByOcrResultIdDesc(contract)
                 .orElseThrow(() -> new CustomException(ErrorCode.OCR_RESULT_NOT_FOUND));
 
         // 2. OCR 텍스트 전처리 및 줄 단위 분리

--- a/backend/src/main/java/com/safesign/backend/domain/ocr/controller/OcrController.java
+++ b/backend/src/main/java/com/safesign/backend/domain/ocr/controller/OcrController.java
@@ -1,6 +1,7 @@
 package com.safesign.backend.domain.ocr.controller;
 
 import com.safesign.backend.domain.contract.service.ContractAiAnalysisService;
+import com.safesign.backend.domain.contract.service.ContractParsingService;
 import com.safesign.backend.domain.ocr.dto.response.OcrResponse;
 import com.safesign.backend.domain.ocr.service.OcrQueryService;
 import com.safesign.backend.domain.ocr.service.OcrService;
@@ -23,6 +24,7 @@ public class OcrController {
 
     private final OcrService ocrService;
     private final OcrQueryService ocrQueryService;
+    private final ContractParsingService parsingService;
     private final ContractAiAnalysisService contractAiAnalysisService;
 
     @PostMapping("/{contractId}/ocr")
@@ -31,15 +33,23 @@ public class OcrController {
             @PathVariable Long contractId,
             @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authorization
     ) {
+        // 1. OCR 처리 및 OCR 결과 DB 저장
         ocrService.process(userDetails.getUserId(), contractId);
 
+        // 2. OCR 결과 기반 조항 파싱 실행
+        parsingService.parse(
+                userDetails.getUserId(),
+                contractId
+        );
+
+        // 3. AI 분석 요청 및 AI 결과 DB 저장
         contractAiAnalysisService.analyzeFromOcr(
                 userDetails.getUserId(),
                 contractId,
                 authorization
         );
 
-        return ResponseEntity.ok("OCR 및 AI 분석 처리가 완료되었습니다.");
+        return ResponseEntity.ok("OCR, 파싱 및 AI 분석 처리가 완료되었습니다.");
     }
 
     @GetMapping("/{contractId}/ocr")

--- a/backend/src/main/java/com/safesign/backend/global/exception/CustomException.java
+++ b/backend/src/main/java/com/safesign/backend/global/exception/CustomException.java
@@ -11,4 +11,9 @@ public class CustomException extends RuntimeException {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
     }
+
+    public CustomException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
 }

--- a/backend/src/main/java/com/safesign/backend/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/safesign/backend/global/exception/ErrorCode.java
@@ -26,8 +26,8 @@ public enum ErrorCode {
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 올바르지 않습니다."),
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
     ANALYSIS_LOG_NOT_FOUND(HttpStatus.NOT_FOUND, "분석 로그를 찾을 수 없습니다."),
-    ANALYSIS_RESULT_NOT_FOUND(HttpStatus.NOT_FOUND, "분석 결과를 찾을 수 없습니다.");
-
+    ANALYSIS_RESULT_NOT_FOUND(HttpStatus.NOT_FOUND, "분석 결과를 찾을 수 없습니다."),
+    PARSE_RESULT_NOT_FOUND(HttpStatus.NOT_FOUND, "파싱 결과를 찾을 수 없습니다.");
     private final HttpStatus status;
     private final String message;
 }

--- a/backend/src/main/java/com/safesign/backend/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/safesign/backend/global/exception/ErrorCode.java
@@ -25,7 +25,8 @@ public enum ErrorCode {
 
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 올바르지 않습니다."),
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
-    ANALYSIS_LOG_NOT_FOUND(HttpStatus.NOT_FOUND, "분석 로그를 찾을 수 없습니다.");
+    ANALYSIS_LOG_NOT_FOUND(HttpStatus.NOT_FOUND, "분석 로그를 찾을 수 없습니다."),
+    ANALYSIS_RESULT_NOT_FOUND(HttpStatus.NOT_FOUND, "분석 결과를 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/backend/src/main/java/com/safesign/backend/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/safesign/backend/global/exception/GlobalExceptionHandler.java
@@ -19,7 +19,7 @@ public class GlobalExceptionHandler {
                         ErrorResponse.builder()
                                 .status(errorCode.getStatus().value())
                                 .error(errorCode.getStatus().name())
-                                .message(errorCode.getMessage())
+                                .message(e.getMessage())
                                 .timestamp(LocalDateTime.now())
                                 .build()
                 );

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -74,6 +74,7 @@ jwt:
 
 app:
   frontend-url: ${FRONTEND_URL}
+  local-frontend-url: ${LOCAL_FRONTEND_URL:http://localhost:3000}
 
   cookie:
     secure: ${COOKIE_SECURE}
@@ -87,4 +88,4 @@ aws:
 
 ai:
   service:
-    base-url: ${AI_SERVICE_BASE_URL:https://safesign-ai.site/ai-docs}
+    base-url: ${AI_SERVICE_BASE_URL:http://ai-service:8000/}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -89,3 +89,5 @@ aws:
 ai:
   service:
     base-url: ${AI_SERVICE_BASE_URL:http://ai-service:8000/}
+  debug:
+    expose-error: true


### PR DESCRIPTION
## 📌 관련 이슈
- 기존 OCR-AI 분석 저장 연동 후속 작업

---

## ✨ PR 유형
- [x] 신규 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

---

## 📋 작업 내용
- 사용자 본인의 계약서 AI 분석 결과 조회 API 추가
- `GET /api/v1/contracts/{contractId}/analysis` 구현
- 전체 위험도, 추천 특약, 조항별 분석 및 관련 법률 응답 제공
- 분석 결과 미존재 시 `ANALYSIS_RESULT_NOT_FOUND` 예외 처리

---

## 🔍 변경 사항
- `ContractAnalysisQueryService` 추가
- `ContractAnalysisResponse` 추가
- `ContractController`에 분석 결과 조회 endpoint 추가
- `ErrorCode`에 분석 결과 미존재 코드 추가

---

## 🧪 테스트
- [x] `./gradlew compileJava` 성공
- [ ] 배포 환경 Swagger 호출 확인

---

## ⚠️ 주의 사항
- 조회 대상은 로그인 사용자가 소유한 계약서로 제한됩니다.
- 동일 계약서의 최신 분석 결과 1건을 반환합니다.
- AI 응답의 `percentile`은 저장 시 `overallRiskScore` 값으로 조회됩니다.