### PR TITLE
Refactor : AI 분석 요청을 파싱 결과 직접 전달 방식으로 변경

### DIFF
--- a/backend/src/main/java/com/safesign/backend/domain/contract/client/AiAnalysisClient.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/client/AiAnalysisClient.java
@@ -1,8 +1,8 @@
 package com.safesign.backend.domain.contract.client;
 
+import com.safesign.backend.domain.contract.dto.request.AiAnalysisRequest;
 import com.safesign.backend.domain.contract.dto.response.AiAnalysisResponse;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
@@ -36,21 +36,11 @@ public class AiAnalysisClient {
                 .build();
     }
 
-    public AiAnalysisResponse analyzeFromOcr(
-            Long contractId,
-            String authorization
-    ) {
-        RestClient.RequestBodySpec request = restClient.post()
-                .uri(uriBuilder -> uriBuilder
-                        .path("/analyze_from_ocr/{contractId}")
-                        .queryParam("explain", true)
-                        .build(contractId));
-
-        if (authorization != null && !authorization.isBlank()) {
-            request.header(HttpHeaders.AUTHORIZATION, authorization);
-        }
-
-        return request.retrieve()
+    public AiAnalysisResponse analyzeContract(AiAnalysisRequest analysisRequest) {
+        return restClient.post()
+                .uri("/analyze_contract")
+                .body(analysisRequest)
+                .retrieve()
                 .body(AiAnalysisResponse.class);
     }
 }

--- a/backend/src/main/java/com/safesign/backend/domain/contract/dto/request/AiAnalysisRequest.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/dto/request/AiAnalysisRequest.java
@@ -1,0 +1,72 @@
+package com.safesign.backend.domain.contract.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.safesign.backend.domain.contract.dto.response.ClauseResponse;
+import com.safesign.backend.domain.contract.dto.response.ParsingResponse;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Getter
+@AllArgsConstructor
+public class AiAnalysisRequest {
+
+    private static final Pattern ARTICLE_NO_PATTERN =
+            Pattern.compile("^(제\\s*\\d+\\s*조|특약\\s*\\d+|특약사항)");
+    private static final Pattern ARTICLE_TITLE_PATTERN =
+            Pattern.compile("\\[([^]]+)]");
+
+    private Long contractId;
+    private List<ClauseRequest> clauses;
+    private boolean explain;
+
+    public static AiAnalysisRequest from(ParsingResponse parsingResponse) {
+        List<ClauseRequest> clauses = parsingResponse.getClauses()
+                .stream()
+                .map(AiAnalysisRequest::toClauseRequest)
+                .toList();
+
+        return new AiAnalysisRequest(
+                parsingResponse.getContractId(),
+                clauses,
+                true
+        );
+    }
+
+    private static ClauseRequest toClauseRequest(ClauseResponse clause) {
+        String title = clause.getTitle();
+
+        return new ClauseRequest(
+                extractArticleNo(title),
+                extractArticleTitle(title),
+                clause.getContent()
+        );
+    }
+
+    private static String extractArticleNo(String title) {
+        Matcher matcher = ARTICLE_NO_PATTERN.matcher(title);
+        return matcher.find() ? matcher.group(1).replaceAll("\\s+", "") : title;
+    }
+
+    private static String extractArticleTitle(String title) {
+        Matcher matcher = ARTICLE_TITLE_PATTERN.matcher(title);
+        return matcher.find() ? matcher.group(1).trim() : title;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class ClauseRequest {
+
+        @JsonProperty("article_no")
+        private String articleNo;
+
+        @JsonProperty("article_title")
+        private String articleTitle;
+
+        @JsonProperty("raw_text")
+        private String rawText;
+    }
+}

--- a/backend/src/main/java/com/safesign/backend/domain/contract/service/ContractAiAnalysisService.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/service/ContractAiAnalysisService.java
@@ -1,7 +1,9 @@
 package com.safesign.backend.domain.contract.service;
 
 import com.safesign.backend.domain.contract.client.AiAnalysisClient;
+import com.safesign.backend.domain.contract.dto.request.AiAnalysisRequest;
 import com.safesign.backend.domain.contract.dto.response.AiAnalysisResponse;
+import com.safesign.backend.domain.contract.dto.response.ParsingResponse;
 import com.safesign.backend.global.exception.CustomException;
 import com.safesign.backend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -21,12 +23,13 @@ public class ContractAiAnalysisService {
     @Value("${ai.debug.expose-error:false}")
     private boolean exposeAiError;
 
-    public void analyzeFromOcr(Long userId, Long contractId, String authorization) {
+    public void analyzeContract(Long userId, Long contractId, ParsingResponse parsingResponse) {
         persistenceService.markProcessing(userId, contractId);
 
         try {
+            AiAnalysisRequest request = AiAnalysisRequest.from(parsingResponse);
             AiAnalysisResponse response =
-                    aiAnalysisClient.analyzeFromOcr(contractId, authorization);
+                    aiAnalysisClient.analyzeContract(request);
 
             if (response == null || response.getOverallAnalysis() == null) {
                 throw new IllegalStateException("AI analysis response is empty.");

--- a/backend/src/main/java/com/safesign/backend/domain/ocr/controller/OcrController.java
+++ b/backend/src/main/java/com/safesign/backend/domain/ocr/controller/OcrController.java
@@ -2,18 +2,17 @@ package com.safesign.backend.domain.ocr.controller;
 
 import com.safesign.backend.domain.contract.service.ContractAiAnalysisService;
 import com.safesign.backend.domain.contract.service.ContractParsingService;
+import com.safesign.backend.domain.contract.dto.response.ParsingResponse;
 import com.safesign.backend.domain.ocr.dto.response.OcrResponse;
 import com.safesign.backend.domain.ocr.service.OcrQueryService;
 import com.safesign.backend.domain.ocr.service.OcrService;
 import com.safesign.backend.global.auth.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -30,23 +29,22 @@ public class OcrController {
     @PostMapping("/{contractId}/ocr")
     public ResponseEntity<String> processOcr(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @PathVariable Long contractId,
-            @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authorization
+            @PathVariable Long contractId
     ) {
         // 1. OCR 처리 및 OCR 결과 DB 저장
         ocrService.process(userDetails.getUserId(), contractId);
 
         // 2. OCR 결과 기반 조항 파싱 실행
-        parsingService.parse(
+        ParsingResponse parsingResponse = parsingService.parse(
                 userDetails.getUserId(),
                 contractId
         );
 
         // 3. AI 분석 요청 및 AI 결과 DB 저장
-        contractAiAnalysisService.analyzeFromOcr(
+        contractAiAnalysisService.analyzeContract(
                 userDetails.getUserId(),
                 contractId,
-                authorization
+                parsingResponse
         );
 
         return ResponseEntity.ok("OCR, 파싱 및 AI 분석 처리가 완료되었습니다.");


### PR DESCRIPTION
## 🧾 PR 제목
[Refactor/#44] AI 분석 요청을 파싱 결과 직접 전달 방식으로 변경
예: [Feat/#1] 로그인 기능 추가

---

## 📌 관련 이슈
- Closes #44
---

## ✨ PR 유형
- [ ] 신규 기능
- [X] 버그 수정
- [X] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명 필요)

---

## 📋 작업 내용
- OCR 완료 후 파싱된 조항 데이터를 AI 분석 API에 직접 전달하도록 변경
- AI 서비스의 백엔드 /parse 재호출 및 인증 헤더 의존 제거
- AI 응답 대기 timeout 조정 및 OCR/파싱 결과 재사용 처리

---

## 🔍 변경 사항
- AiAnalysisRequest DTO 추가
- AI 호출 API를 /analyze_from_ocr/{contractId}에서 /analyze_contract로 변경
- ParsingResponse를 AI 요청 body 형식으로 변환하여 전달
- 완료된 OCR 및 기존 파싱 결과가 존재하면 재사용
- AI 응답 read timeout을 5분로 설정
- 중복 OCR 엔티티 및 Repository 제거

---

## 🧪 테스트
- [ ] 로컬 실행 확인
- [ ] DB 연결 확인
- [ ] API 정상 동작 확인 (Swagger 등)
- [ ] 기타 테스트:

---

## ⚠️ 주의 사항 (중요)
- 환경변수 변경 여부
- DB 구조 변경 여부
- 팀원에게 영향 있는 부분

---

## 📸 스크린샷 (선택)
- UI 변경 시 첨부

---

## 🔗 참고 자료
- 관련 문서 / 링크

---

## 📌 리뷰 요구 사항
- 집중적으로 봐야 할 부분
- 고민했던 부분

---

## 📌 PR 규칙
- 최소 1명 이상 승인 후 merge
- main 직접 push 금지
- dev 또는 feature 브랜치 사용