### PR TITLE
bug: OCR + Parsing API 와 AI 분석 + DB 저장 API로 분리

### DIFF
--- a/backend/src/main/java/com/safesign/backend/domain/contract/controller/ContractController.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/controller/ContractController.java
@@ -1,19 +1,23 @@
 package com.safesign.backend.domain.contract.controller;
 
-import com.safesign.backend.domain.contract.dto.response.ContractUploadResponse;
-import com.safesign.backend.domain.contract.dto.response.ContractListResponse;
+import com.safesign.backend.domain.contract.dto.response.AnalysisStartResponse;
+import com.safesign.backend.domain.contract.dto.response.AnalysisStatusResponse;
 import com.safesign.backend.domain.contract.dto.response.ContractAnalysisResponse;
+import com.safesign.backend.domain.contract.dto.response.ContractListResponse;
+import com.safesign.backend.domain.contract.dto.response.ContractUploadResponse;
 import com.safesign.backend.domain.contract.enums.UploadType;
-import com.safesign.backend.domain.contract.service.ContractService;
-import com.safesign.backend.domain.contract.service.ContractQueryService;
+import com.safesign.backend.domain.contract.service.ContractAiAnalysisService;
 import com.safesign.backend.domain.contract.service.ContractAnalysisQueryService;
+import com.safesign.backend.domain.contract.service.ContractAnalysisStatusQueryService;
+import com.safesign.backend.domain.contract.service.ContractQueryService;
+import com.safesign.backend.domain.contract.service.ContractService;
 import com.safesign.backend.global.auth.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
 import java.util.List;
 
@@ -25,6 +29,8 @@ public class ContractController {
     private final ContractService contractService;
     private final ContractQueryService contractQueryService;
     private final ContractAnalysisQueryService contractAnalysisQueryService;
+    private final ContractAnalysisStatusQueryService contractAnalysisStatusQueryService;
+    private final ContractAiAnalysisService contractAiAnalysisService;
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @ResponseStatus(HttpStatus.CREATED)
@@ -50,6 +56,32 @@ public class ContractController {
         return contractQueryService.getContracts(userId, keyword, sort);
     }
 
+    // AI 분석 시작 API
+    @PostMapping("/{contractId}/analysis")
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public AnalysisStartResponse startAnalysis(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long contractId
+    ) {
+        return contractAiAnalysisService.startAnalysis(
+                userDetails.getUserId(),
+                contractId
+        );
+    }
+
+    // AI 분석 상태 조회 API
+    @GetMapping("/{contractId}/analysis/status")
+    public AnalysisStatusResponse getAnalysisStatus(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long contractId
+    ) {
+        return contractAnalysisStatusQueryService.getAnalysisStatus(
+                userDetails.getUserId(),
+                contractId
+        );
+    }
+
+    // AI 분석 결과 조회 API
     @GetMapping("/{contractId}/analysis")
     public ContractAnalysisResponse getAnalysisResult(
             @AuthenticationPrincipal CustomUserDetails userDetails,

--- a/backend/src/main/java/com/safesign/backend/domain/contract/dto/response/AnalysisStartResponse.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/dto/response/AnalysisStartResponse.java
@@ -1,0 +1,13 @@
+package com.safesign.backend.domain.contract.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AnalysisStartResponse {
+
+    private Long contractId;
+    private String status;
+    private String message;
+}

--- a/backend/src/main/java/com/safesign/backend/domain/contract/dto/response/AnalysisStatusResponse.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/dto/response/AnalysisStatusResponse.java
@@ -1,0 +1,16 @@
+package com.safesign.backend.domain.contract.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class AnalysisStatusResponse {
+
+    private Long contractId;
+    private String status;
+    private String message;
+    private LocalDateTime analyzedAt;
+}

--- a/backend/src/main/java/com/safesign/backend/domain/contract/service/ContractAiAnalysisService.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/service/ContractAiAnalysisService.java
@@ -1,81 +1,38 @@
 package com.safesign.backend.domain.contract.service;
 
-import com.safesign.backend.domain.contract.client.AiAnalysisClient;
-import com.safesign.backend.domain.contract.dto.request.AiAnalysisRequest;
-import com.safesign.backend.domain.contract.dto.response.AiAnalysisResponse;
-import com.safesign.backend.domain.contract.dto.response.ParsingResponse;
+import com.safesign.backend.domain.contract.dto.response.AnalysisStartResponse;
+import com.safesign.backend.domain.contract.repository.ContractRepository;
 import com.safesign.backend.global.exception.CustomException;
 import com.safesign.backend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestClientResponseException;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class ContractAiAnalysisService {
 
-    private final AiAnalysisClient aiAnalysisClient;
+    private final ContractRepository contractRepository;
     private final ContractAnalysisPersistenceService persistenceService;
+    private final ContractAiAnalysisWorker analysisWorker;
 
-    @Value("${ai.debug.expose-error:false}")
-    private boolean exposeAiError;
+    public AnalysisStartResponse startAnalysis(Long userId, Long contractId) {
+        contractRepository.findByContractIdAndUser_UserId(contractId, userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.CONTRACT_NOT_FOUND));
 
-    public void analyzeContract(Long userId, Long contractId, ParsingResponse parsingResponse) {
+        // 분석 상태를 PROCESSING으로 먼저 저장
         persistenceService.markProcessing(userId, contractId);
 
-        try {
-            AiAnalysisRequest request = AiAnalysisRequest.from(parsingResponse);
+        // 실제 AI 호출은 비동기로 실행
+        analysisWorker.analyzeAsync(userId, contractId);
 
-            log.info(
-                    "AI analysis request sending - contractId={}, clauseCount={}",
-                    contractId,
-                    request.getClauses().size()
-            );
+        log.info("AI analysis accepted - contractId={}", contractId);
 
-            AiAnalysisResponse response =
-                    aiAnalysisClient.analyzeContract(request);
-
-            if (response == null || response.getOverallAnalysis() == null) {
-                throw new IllegalStateException("AI analysis response is empty.");
-            }
-
-            log.info(
-                    "AI analysis response received - contractId={}, overallRiskScore={}, percentile={}, clauseCount={}",
-                    contractId,
-                    response.getOverallAnalysis().getOverallRiskScore(),
-                    response.getOverallAnalysis().getPercentile(),
-                    response.getClauseAnalyses() == null ? 0 : response.getClauseAnalyses().size()
-            );
-
-            persistenceService.saveCompletedResult(userId, contractId, response);
-            log.info("AI analysis result saved - contractId={}", contractId);
-        } catch (RestClientResponseException e) {
-            log.error(
-                    "AI analysis API failed - contractId={}, status={}, responseBody={}",
-                    contractId,
-                    e.getStatusCode(),
-                    e.getResponseBodyAsString(),
-                    e
-            );
-            persistenceService.markFailed(userId, contractId);
-            throw toAnalysisException(
-                    "AI API " + e.getStatusCode() + ": " + e.getResponseBodyAsString()
-            );
-        } catch (Exception e) {
-            log.error("AI analysis failed - contractId={}", contractId, e);
-            persistenceService.markFailed(userId, contractId);
-            throw toAnalysisException(e.getMessage());
-        }
-    }
-
-    private CustomException toAnalysisException(String detail) {
-        if (exposeAiError && detail != null && !detail.isBlank()) {
-            return new CustomException(ErrorCode.AI_ANALYSIS_FAILED, detail);
-        }
-
-        return new CustomException(ErrorCode.AI_ANALYSIS_FAILED);
+        return new AnalysisStartResponse(
+                contractId,
+                "PROCESSING",
+                "AI 분석이 시작되었습니다."
+        );
     }
 }

--- a/backend/src/main/java/com/safesign/backend/domain/contract/service/ContractAiAnalysisWorker.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/service/ContractAiAnalysisWorker.java
@@ -1,0 +1,76 @@
+package com.safesign.backend.domain.contract.service;
+
+import com.safesign.backend.domain.contract.client.AiAnalysisClient;
+import com.safesign.backend.domain.contract.dto.request.AiAnalysisRequest;
+import com.safesign.backend.domain.contract.dto.response.AiAnalysisResponse;
+import com.safesign.backend.domain.contract.dto.response.ParsingResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientResponseException;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ContractAiAnalysisWorker {
+
+    private final ContractParsingQueryService parsingQueryService;
+    private final AiAnalysisClient aiAnalysisClient;
+    private final ContractAnalysisPersistenceService persistenceService;
+
+    @Async("aiAnalysisExecutor")
+    public void analyzeAsync(Long userId, Long contractId) {
+        try {
+            log.info("AI async analysis started - contractId={}", contractId);
+
+            // 이미 DB에 저장된 파싱 결과 조회
+            ParsingResponse parsingResponse =
+                    parsingQueryService.getParsedResult(userId, contractId);
+
+            AiAnalysisRequest request =
+                    AiAnalysisRequest.from(parsingResponse);
+
+            log.info(
+                    "AI async request sending - contractId={}, clauseCount={}",
+                    contractId,
+                    request.getClauses().size()
+            );
+
+            AiAnalysisResponse response =
+                    aiAnalysisClient.analyzeContract(request);
+
+            if (response == null || response.getOverallAnalysis() == null) {
+                throw new IllegalStateException("AI analysis response is empty.");
+            }
+
+            log.info(
+                    "AI async response received - contractId={}, overallRiskScore={}, percentile={}, clauseCount={}",
+                    contractId,
+                    response.getOverallAnalysis().getOverallRiskScore(),
+                    response.getOverallAnalysis().getPercentile(),
+                    response.getClauseAnalyses() == null ? 0 : response.getClauseAnalyses().size()
+            );
+
+            persistenceService.saveCompletedResult(userId, contractId, response);
+
+            log.info("AI async analysis result saved - contractId={}", contractId);
+
+        } catch (RestClientResponseException e) {
+            log.error(
+                    "AI async API failed - contractId={}, status={}, responseBody={}",
+                    contractId,
+                    e.getStatusCode(),
+                    e.getResponseBodyAsString(),
+                    e
+            );
+
+            persistenceService.markFailed(userId, contractId);
+
+        } catch (Exception e) {
+            log.error("AI async analysis failed - contractId={}", contractId, e);
+
+            persistenceService.markFailed(userId, contractId);
+        }
+    }
+}

--- a/backend/src/main/java/com/safesign/backend/domain/contract/service/ContractAnalysisStatusQueryService.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/service/ContractAnalysisStatusQueryService.java
@@ -1,0 +1,45 @@
+package com.safesign.backend.domain.contract.service;
+
+import com.safesign.backend.domain.contract.dto.response.AnalysisStatusResponse;
+import com.safesign.backend.domain.contract.entity.ContractAnalysisResult;
+import com.safesign.backend.domain.contract.repository.ContractAnalysisResultRepository;
+import com.safesign.backend.domain.contract.repository.ContractRepository;
+import com.safesign.backend.global.exception.CustomException;
+import com.safesign.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ContractAnalysisStatusQueryService {
+
+    private final ContractRepository contractRepository;
+    private final ContractAnalysisResultRepository analysisResultRepository;
+
+    public AnalysisStatusResponse getAnalysisStatus(Long userId, Long contractId) {
+        contractRepository.findByContractIdAndUser_UserId(contractId, userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.CONTRACT_NOT_FOUND));
+
+        ContractAnalysisResult latestResult = analysisResultRepository
+                .findTopByContract_ContractIdOrderByCreatedAtDesc(contractId)
+                .orElse(null);
+
+        if (latestResult == null) {
+            return AnalysisStatusResponse.builder()
+                    .contractId(contractId)
+                    .status("PROCESSING")
+                    .message("AI 분석 중이거나 아직 분석 결과가 없습니다.")
+                    .analyzedAt(null)
+                    .build();
+        }
+
+        return AnalysisStatusResponse.builder()
+                .contractId(contractId)
+                .status("COMPLETED")
+                .message("AI 분석이 완료되었습니다.")
+                .analyzedAt(latestResult.getCreatedAt())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/safesign/backend/domain/ocr/controller/OcrController.java
+++ b/backend/src/main/java/com/safesign/backend/domain/ocr/controller/OcrController.java
@@ -1,8 +1,7 @@
 package com.safesign.backend.domain.ocr.controller;
 
-import com.safesign.backend.domain.contract.service.ContractAiAnalysisService;
-import com.safesign.backend.domain.contract.service.ContractParsingService;
 import com.safesign.backend.domain.contract.dto.response.ParsingResponse;
+import com.safesign.backend.domain.contract.service.ContractParsingService;
 import com.safesign.backend.domain.ocr.dto.response.OcrResponse;
 import com.safesign.backend.domain.ocr.service.OcrQueryService;
 import com.safesign.backend.domain.ocr.service.OcrService;
@@ -10,11 +9,7 @@ import com.safesign.backend.global.auth.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,30 +19,23 @@ public class OcrController {
     private final OcrService ocrService;
     private final OcrQueryService ocrQueryService;
     private final ContractParsingService parsingService;
-    private final ContractAiAnalysisService contractAiAnalysisService;
 
     @PostMapping("/{contractId}/ocr")
-    public ResponseEntity<String> processOcr(
+    public ResponseEntity<ParsingResponse> processOcr(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long contractId
     ) {
         // 1. OCR 처리 및 OCR 결과 DB 저장
         ocrService.process(userDetails.getUserId(), contractId);
 
-        // 2. OCR 결과 기반 조항 파싱 실행
+        // 2. OCR 결과 기반 조항 파싱 실행 및 DB 저장
         ParsingResponse parsingResponse = parsingService.parse(
                 userDetails.getUserId(),
                 contractId
         );
 
-        // 3. AI 분석 요청 및 AI 결과 DB 저장
-        contractAiAnalysisService.analyzeContract(
-                userDetails.getUserId(),
-                contractId,
-                parsingResponse
-        );
-
-        return ResponseEntity.ok("OCR, 파싱 및 AI 분석 처리가 완료되었습니다.");
+        // 3. AI 분석은 여기서 실행하지 않음
+        return ResponseEntity.ok(parsingResponse);
     }
 
     @GetMapping("/{contractId}/ocr")

--- a/backend/src/main/java/com/safesign/backend/global/config/AsyncConfig.java
+++ b/backend/src/main/java/com/safesign/backend/global/config/AsyncConfig.java
@@ -1,0 +1,26 @@
+package com.safesign.backend.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean(name = "aiAnalysisExecutor")
+    public Executor aiAnalysisExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(4);
+        executor.setQueueCapacity(50);
+        executor.setThreadNamePrefix("ai-analysis-");
+
+        executor.initialize();
+        return executor;
+    }
+}


### PR DESCRIPTION
## 🧾 PR 제목
[Bug/#59] OCR + Parsing API 와 AI 분석 + DB 저장 API로 분리
예: [Feat/#1] 로그인 기능 추가

---

## 📌 관련 이슈
- Closes #59

---

## ✨ PR 유형
- [ ] 신규 기능
- [X] 버그 수정
- [X] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명 필요)

---

## 📋 작업 내용
- OCR 처리 API와 AI 분석 API의 역할을 분리
- OCR API에서는 OCR 수행 및 파싱 결과 저장까지만 처리하도록 변경
- AI 분석은 별도 API에서 시작되며, 비동기 방식으로 분석 및 결과 저장이 진행되도록 수정
---

## 🔍 변경 사항
- `/api/v1/contracts/{contractId}/ocr` API에서 AI 분석 호출 로직 제거
- `/api/v1/contracts/{contractId}/analysis` AI 분석 시작 API 추가
- AI 분석 요청을 비동기 처리하는 Worker 구조 추가
- 분석 상태 조회용 API 및 응답 DTO 추가
- `@EnableAsync` 및 AI 분석 전용 Executor 설정 추가
- DB 변경 없음
- API 변경 있음
  - OCR API: OCR + 파싱까지만 수행
  - AI 분석 API: 분석 시작 및 결과 조회 분리
- 설정 변경 있음
  - 비동기 처리를 위한 Async 설정 추가

---

## 🧪 테스트
- [X] 로컬 실행 확인
- [X] DB 연결 확인
- [X] API 정상 동작 확인 (Swagger 등)
- [ ] 기타 테스트:

---

## ⚠️ 주의 사항 (중요)
- 환경변수 변경 여부
- DB 구조 변경 여부
- 팀원에게 영향 있는 부분

---

## 📸 스크린샷 (선택)
- UI 변경 시 첨부

---

## 🔗 참고 자료
- 관련 문서 / 링크

---

## 📌 리뷰 요구 사항
- 집중적으로 봐야 할 부분
- 고민했던 부분

---

## 📌 PR 규칙
- 최소 1명 이상 승인 후 merge
- main 직접 push 금지
- dev 또는 feature 브랜치 사용