### PR TITLE
bug: Kst 시간으로 수정

### DIFF
--- a/backend/src/main/java/com/safesign/backend/domain/admin/dto/request/AdminAnalysisFilterCondition.java
+++ b/backend/src/main/java/com/safesign/backend/domain/admin/dto/request/AdminAnalysisFilterCondition.java
@@ -1,5 +1,7 @@
 package com.safesign.backend.domain.admin.dto.request;
 
+import com.safesign.backend.global.util.KstTime;
+
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
@@ -27,7 +29,7 @@ public record AdminAnalysisFilterCondition(
             return null;
         }
 
-        LocalDate today = LocalDate.now();
+        LocalDate today = KstTime.today();
 
         if (period.equalsIgnoreCase("TODAY")) {
             return today.atStartOfDay();
@@ -50,7 +52,7 @@ public record AdminAnalysisFilterCondition(
             return null;
         }
 
-        return LocalDate.now().plusDays(1).atStartOfDay();
+        return KstTime.today().plusDays(1).atStartOfDay();
     }
 
     public String getStatusForSearch() {

--- a/backend/src/main/java/com/safesign/backend/domain/admin/service/AdminDashboardService.java
+++ b/backend/src/main/java/com/safesign/backend/domain/admin/service/AdminDashboardService.java
@@ -5,6 +5,7 @@ import com.safesign.backend.domain.admin.dto.response.AdminDashboardRecentUserRe
 import com.safesign.backend.domain.admin.dto.response.AdminDashboardResponse;
 import com.safesign.backend.domain.admin.dto.response.AdminDashboardSummaryResponse;
 import com.safesign.backend.domain.admin.repository.AdminDashboardRepository;
+import com.safesign.backend.global.util.KstTime;
 
 import lombok.RequiredArgsConstructor;
 
@@ -25,7 +26,7 @@ public class AdminDashboardService {
 
     public AdminDashboardResponse getDashboard() {
 
-        LocalDate today = LocalDate.now();
+        LocalDate today = KstTime.today();
         LocalDateTime startAt = today.atStartOfDay();
         LocalDateTime endAt = today.plusDays(1).atStartOfDay();
 
@@ -161,7 +162,7 @@ public class AdminDashboardService {
 
         Duration duration = Duration.between(
                 targetTime,
-                LocalDateTime.now()
+                KstTime.now()
         );
 
         long minutes = duration.toMinutes();

--- a/backend/src/main/java/com/safesign/backend/domain/contract/entity/Contract.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/entity/Contract.java
@@ -5,6 +5,7 @@ import com.safesign.backend.domain.contract.enums.UploadSource;
 import com.safesign.backend.domain.contract.enums.UploadType;
 import com.safesign.backend.domain.user.entity.User;
 import com.safesign.backend.domain.ocr.entity.OcrResult;
+import com.safesign.backend.global.util.KstTime;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -123,16 +124,18 @@ public class Contract {
 
     @PrePersist
     protected void onCreate() {
-        this.createdAt = LocalDateTime.now();
-        this.updatedAt = LocalDateTime.now();
+        LocalDateTime now = KstTime.now();
+
+        this.createdAt = now;
+        this.updatedAt = now;
 
         if (this.uploadedAt == null) {
-            this.uploadedAt = LocalDateTime.now();
+            this.uploadedAt = now;
         }
     }
 
     @PreUpdate
     protected void onUpdate() {
-        this.updatedAt = LocalDateTime.now();
+        this.updatedAt = KstTime.now();
     }
 }

--- a/backend/src/main/java/com/safesign/backend/domain/contract/entity/ContractAnalysisResult.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/entity/ContractAnalysisResult.java
@@ -1,5 +1,6 @@
 package com.safesign.backend.domain.contract.entity;
 
+import com.safesign.backend.global.util.KstTime;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -77,12 +78,14 @@ public class ContractAnalysisResult {
 
     @PrePersist
     protected void onCreate() {
-        this.createdAt = LocalDateTime.now();
-        this.updatedAt = LocalDateTime.now();
+        LocalDateTime now = KstTime.now();
+
+        this.createdAt = now;
+        this.updatedAt = now;
     }
 
     @PreUpdate
     protected void onUpdate() {
-        this.updatedAt = LocalDateTime.now();
+        this.updatedAt = KstTime.now();
     }
 }

--- a/backend/src/main/java/com/safesign/backend/domain/contract/entity/ContractClause.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/entity/ContractClause.java
@@ -1,5 +1,6 @@
 package com.safesign.backend.domain.contract.entity;
 
+import com.safesign.backend.global.util.KstTime;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -46,12 +47,14 @@ public class ContractClause {
 
     @PrePersist
     protected void onCreate() {
-        this.createdAt = LocalDateTime.now();
-        this.updatedAt = LocalDateTime.now();
+        LocalDateTime now = KstTime.now();
+
+        this.createdAt = now;
+        this.updatedAt = now;
     }
 
     @PreUpdate
     protected void onUpdate() {
-        this.updatedAt = LocalDateTime.now();
+        this.updatedAt = KstTime.now();
     }
 }

--- a/backend/src/main/java/com/safesign/backend/domain/contract/entity/ContractFile.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/entity/ContractFile.java
@@ -1,5 +1,6 @@
 package com.safesign.backend.domain.contract.entity;
 
+import com.safesign.backend.global.util.KstTime;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -65,6 +66,6 @@ public class ContractFile {
 
     @PrePersist
     protected void onCreate() {
-        this.createdAt = LocalDateTime.now();
+        this.createdAt = KstTime.now();
     }
 }

--- a/backend/src/main/java/com/safesign/backend/domain/contract/entity/ContractHeaderInfo.java
+++ b/backend/src/main/java/com/safesign/backend/domain/contract/entity/ContractHeaderInfo.java
@@ -1,5 +1,6 @@
 package com.safesign.backend.domain.contract.entity;
 
+import com.safesign.backend.global.util.KstTime;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -71,14 +72,15 @@ public class ContractHeaderInfo {
 
     @PrePersist
     protected void onCreate() {
+        LocalDateTime now = KstTime.now();
 
-        this.createdAt = LocalDateTime.now();
-        this.updatedAt = LocalDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
     }
 
     @PreUpdate
     protected void onUpdate() {
 
-        this.updatedAt = LocalDateTime.now();
+        this.updatedAt = KstTime.now();
     }
 }

--- a/backend/src/main/java/com/safesign/backend/domain/dashboard/service/DashboardService.java
+++ b/backend/src/main/java/com/safesign/backend/domain/dashboard/service/DashboardService.java
@@ -11,6 +11,7 @@ import com.safesign.backend.domain.user.entity.User;
 import com.safesign.backend.domain.user.repository.UserRepository;
 import com.safesign.backend.global.exception.CustomException;
 import com.safesign.backend.global.exception.ErrorCode;
+import com.safesign.backend.global.util.KstTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -39,7 +40,7 @@ public class DashboardService {
         Long riskyContracts = contractAnalysisResultRepository
                 .countRiskyAnalysesByUserId(userId, RISKY_SCORE_THRESHOLD);
 
-        LocalDate now = LocalDate.now();
+        LocalDate now = KstTime.today();
         LocalDateTime startOfMonth = now.withDayOfMonth(1).atStartOfDay();
         LocalDateTime startOfNextMonth = startOfMonth.plusMonths(1);
 

--- a/backend/src/main/java/com/safesign/backend/domain/ocr/entity/OcrLine.java
+++ b/backend/src/main/java/com/safesign/backend/domain/ocr/entity/OcrLine.java
@@ -1,5 +1,6 @@
 package com.safesign.backend.domain.ocr.entity;
 
+import com.safesign.backend.global.util.KstTime;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -50,6 +51,6 @@ public class OcrLine {
 
     @PrePersist
     protected void onCreate() {
-        this.createdAt = LocalDateTime.now();
+        this.createdAt = KstTime.now();
     }
 }

--- a/backend/src/main/java/com/safesign/backend/domain/ocr/entity/OcrPage.java
+++ b/backend/src/main/java/com/safesign/backend/domain/ocr/entity/OcrPage.java
@@ -1,5 +1,6 @@
 package com.safesign.backend.domain.ocr.entity;
 
+import com.safesign.backend.global.util.KstTime;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -65,6 +66,6 @@ public class OcrPage {
 
     @PrePersist
     protected void onCreate() {
-        this.createdAt = LocalDateTime.now();
+        this.createdAt = KstTime.now();
     }
 }

--- a/backend/src/main/java/com/safesign/backend/domain/ocr/entity/OcrResult.java
+++ b/backend/src/main/java/com/safesign/backend/domain/ocr/entity/OcrResult.java
@@ -2,6 +2,7 @@ package com.safesign.backend.domain.ocr.entity;
 
 import com.safesign.backend.domain.contract.entity.Contract;
 import com.safesign.backend.domain.ocr.enums.OcrStatus;
+import com.safesign.backend.global.util.KstTime;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -85,14 +86,14 @@ public class OcrResult {
         this.fullText = fullText;
         this.rawJson = rawJson;
         this.status = OcrStatus.COMPLETED;
-        this.completedAt = LocalDateTime.now();
+        this.completedAt = KstTime.now();
         this.failureReason = null;
     }
 
     public void fail(String failureReason) {
         this.status = OcrStatus.FAILED;
         this.failureReason = failureReason;
-        this.completedAt = LocalDateTime.now();
+        this.completedAt = KstTime.now();
     }
 
     public void updateStatus(OcrStatus status) {
@@ -101,16 +102,18 @@ public class OcrResult {
 
     @PrePersist
     protected void onCreate() {
-        this.createdAt = LocalDateTime.now();
-        this.updatedAt = LocalDateTime.now();
+        LocalDateTime now = KstTime.now();
+
+        this.createdAt = now;
+        this.updatedAt = now;
 
         if (this.startedAt == null) {
-            this.startedAt = LocalDateTime.now();
+            this.startedAt = now;
         }
     }
 
     @PreUpdate
     protected void onUpdate() {
-        this.updatedAt = LocalDateTime.now();
+        this.updatedAt = KstTime.now();
     }
 }

--- a/backend/src/main/java/com/safesign/backend/domain/ocr/service/OcrService.java
+++ b/backend/src/main/java/com/safesign/backend/domain/ocr/service/OcrService.java
@@ -21,13 +21,13 @@ import com.safesign.backend.domain.ocr.repository.OcrPageRepository;
 import com.safesign.backend.domain.ocr.repository.OcrResultRepository;
 import com.safesign.backend.global.exception.CustomException;
 import com.safesign.backend.global.exception.ErrorCode;
+import com.safesign.backend.global.util.KstTime;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Slf4j
@@ -67,7 +67,7 @@ public class OcrService {
                 .provider(OCR_PROVIDER)
                 .modelId(azureOcrProperties.modelId())
                 .status(OcrStatus.PROCESSING)
-                .startedAt(LocalDateTime.now())
+                .startedAt(KstTime.now())
                 .build();
 
         ocrResultRepository.save(ocrResult);

--- a/backend/src/main/java/com/safesign/backend/domain/user/entity/User.java
+++ b/backend/src/main/java/com/safesign/backend/domain/user/entity/User.java
@@ -2,6 +2,7 @@ package com.safesign.backend.domain.user.entity;
 
 import com.safesign.backend.domain.user.enums.ProviderType;
 import com.safesign.backend.domain.user.enums.UserRole;
+import com.safesign.backend.global.util.KstTime;
 
 import jakarta.persistence.*;
 
@@ -87,9 +88,10 @@ public class User {
 
     @PrePersist
     protected void onCreate() {
+        LocalDateTime now = KstTime.now();
 
-        this.createdAt = LocalDateTime.now();
-        this.updatedAt = LocalDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
 
         if (this.role == null) {
             this.role = UserRole.USER;
@@ -99,11 +101,11 @@ public class User {
     @PreUpdate
     protected void onUpdate() {
 
-        this.updatedAt = LocalDateTime.now();
+        this.updatedAt = KstTime.now();
     }
 
     public void softDelete() {
-        this.deletedAt = LocalDateTime.now();
+        this.deletedAt = KstTime.now();
     }
 
     public void withdraw() {
@@ -113,6 +115,6 @@ public class User {
         this.password = null;
         this.name = "탈퇴한 사용자";
         this.providerUserId = this.providerUserId + suffix;
-        this.deletedAt = LocalDateTime.now();
+        this.deletedAt = KstTime.now();
     }
 }

--- a/backend/src/main/java/com/safesign/backend/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/safesign/backend/global/exception/GlobalExceptionHandler.java
@@ -1,10 +1,9 @@
 package com.safesign.backend.global.exception;
 
+import com.safesign.backend.global.util.KstTime;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-
-import java.time.LocalDateTime;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -20,7 +19,7 @@ public class GlobalExceptionHandler {
                                 .status(errorCode.getStatus().value())
                                 .error(errorCode.getStatus().name())
                                 .message(e.getMessage())
-                                .timestamp(LocalDateTime.now())
+                                .timestamp(KstTime.now())
                                 .build()
                 );
     }
@@ -28,7 +27,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleException(Exception e) {
 
-        e.printStackTrace(); // 🔥 콘솔에 진짜 에러 출력
+        e.printStackTrace();
 
         return ResponseEntity
                 .internalServerError()
@@ -37,7 +36,7 @@ public class GlobalExceptionHandler {
                                 .status(500)
                                 .error("INTERNAL_SERVER_ERROR")
                                 .message(e.getMessage())
-                                .timestamp(LocalDateTime.now())
+                                .timestamp(KstTime.now())
                                 .build()
                 );
     }

--- a/backend/src/main/java/com/safesign/backend/global/util/KstTime.java
+++ b/backend/src/main/java/com/safesign/backend/global/util/KstTime.java
@@ -1,0 +1,21 @@
+package com.safesign.backend.global.util;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+public final class KstTime {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    private KstTime() {
+    }
+
+    public static LocalDate today() {
+        return LocalDate.now(KST);
+    }
+
+    public static LocalDateTime now() {
+        return LocalDateTime.now(KST);
+    }
+}


### PR DESCRIPTION
## 🧾 PR 제목
[Bug] 시간 저장 및 조회 기준 KST 적용
예: [Feat/#1] 로그인 기능 추가

---

## 📌 관련 이슈
- Closes #이슈번호

---

## ✨ PR 유형
- [ ] 신규 기능
- [X] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명 필요)

---

## 📋 작업 내용
- 서버 기본 timezone에 따라 날짜 필터와 저장 시간이 달라지던 문제를 수정
- 한국 서비스 기준에 맞게 시간 생성 로직을 KST 기준으로 통일
- 관리자 분석 로그 필터의 TODAY, WEEK, MONTH 기준 날짜를 KST 기준으로 변경
- 관리자/사용자 대시보드의 날짜 계산 및 상대 시간 계산을 KST 기준으로 변경

---

## 🔍 변경 사항
- KstTime 유틸 추가
  - LocalDate.now(Asia/Seoul)
  - LocalDateTime.now(Asia/Seoul)
- 엔티티 저장 시간 KST 적용
  - createdAt
  - updatedAt
  - uploadedAt
  - startedAt
  - completedAt
  - deletedAt
- 관리자 분석 로그 필터 기간 계산 KST 적용
- 관리자 대시보드 오늘 기준/상대시간 계산 KST 적용
- 사용자 대시보드 월간 분석 기준 KST 적용

---

## 🧪 테스트
- [ ] 로컬 실행 확인
- [ ] DB 연결 확인
- [ ] API 정상 동작 확인 (Swagger 등)
- [ ] 기타 테스트:

---

## ⚠️ 주의 사항 (중요)
- 기존에 UTC 또는 서버 기본 timezone 기준으로 저장된 데이터는 자동 변환되지 않음

---

## 📸 스크린샷 (선택)
- UI 변경 시 첨부

---

## 🔗 참고 자료
- 관련 문서 / 링크

---

## 📌 리뷰 요구 사항
- 집중적으로 봐야 할 부분
- 고민했던 부분

---

## 📌 PR 규칙
- 최소 1명 이상 승인 후 merge
- main 직접 push 금지
- dev 또는 feature 브랜치 사용