### PR TITLE
feat: 관리자 사용자 분석 이력 응답에 전체 분석 개수 추가

### DIFF
--- a/backend/src/main/java/com/safesign/backend/domain/admin/dto/response/AdminUserAnalysisHistoryResponse.java
+++ b/backend/src/main/java/com/safesign/backend/domain/admin/dto/response/AdminUserAnalysisHistoryResponse.java
@@ -15,5 +15,7 @@ public class AdminUserAnalysisHistoryResponse {
 
     private Long totalAnalysisCount;
 
+    private Long allUserTotalAnalysisCount;
+
     private List<AdminUserAnalysisHistoryItem> histories;
 }

--- a/backend/src/main/java/com/safesign/backend/domain/admin/repository/AdminAnalysisRepository.java
+++ b/backend/src/main/java/com/safesign/backend/domain/admin/repository/AdminAnalysisRepository.java
@@ -55,6 +55,19 @@ public class AdminAnalysisRepository {
         return result.longValue();
     }
 
+    public Long countAllAnalysis() {
+
+        String sql = """
+            SELECT COUNT(*)
+            FROM contract_analysis_result
+        """;
+
+        Number result = (Number) em.createNativeQuery(sql)
+                .getSingleResult();
+
+        return result.longValue();
+    }
+
     public List<Object[]> findAnalysisLogs() {
 
         String sql = """

--- a/backend/src/main/java/com/safesign/backend/domain/admin/service/AdminAnalysisService.java
+++ b/backend/src/main/java/com/safesign/backend/domain/admin/service/AdminAnalysisService.java
@@ -57,10 +57,14 @@ public class AdminAnalysisService {
         Long totalCount =
                 adminAnalysisRepository.countUserAnalysis(userId);
 
+        Long allUserTotalAnalysisCount =
+                adminAnalysisRepository.countAllAnalysis();
+
         return new AdminUserAnalysisHistoryResponse(
                 user.getUserId(),
                 user.getName(),
                 totalCount,
+                allUserTotalAnalysisCount,
                 histories
         );
     }


### PR DESCRIPTION
## 🧾 PR 제목
[Feat] 관리자 사용자 분석 이력 응답에 전체 분석 개수 추가
예: [Feat/#1] 로그인 기능 추가

---

## 📌 관련 이슈
- Closes #이슈번호

---

## ✨ PR 유형
- [X] 신규 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명 필요)

---

## 📋 작업 내용
- 관리자 사용자 분석 이력 조회 API 응답에 전체 사용자 기준 분석 개수 필드 추가
- 기존 해당 사용자 분석 개수는 유지
- 프론트에서 사용자별 분석 수와 서비스 전체 분석 수를 함께 표시할 수 있도록 응답 확장

---

## 🔍 변경 사항
- /api/v1/admin/analysis/users/{userId}/analysis-history 응답 필드 추가
- totalAnalysisCount: 해당 사용자의 전체 분석 개수
- allUserTotalAnalysisCount: 모든 사용자의 전체 분석 개수
- contract_analysis_result 테이블 전체 COUNT 조회 로직 추가

---

## 🧪 테스트
- [ ] 로컬 실행 확인
- [ ] DB 연결 확인
- [ ] API 정상 동작 확인 (Swagger 등)
- [ ] 기타 테스트:

---

## ⚠️ 주의 사항 (중요)
- 환경변수 변경 여부
- DB 구조 변경 여부
- 팀원에게 영향 있는 부분

---

## 📸 스크린샷 (선택)
- UI 변경 시 첨부

---

## 🔗 참고 자료
- 관련 문서 / 링크

---

## 📌 리뷰 요구 사항
- 집중적으로 봐야 할 부분
- 고민했던 부분

---

## 📌 PR 규칙
- 최소 1명 이상 승인 후 merge
- main 직접 push 금지
- dev 또는 feature 브랜치 사용